### PR TITLE
only push on main

### DIFF
--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -23,8 +23,7 @@ on:
         default: true
   push:
     branches:
-      - main           # Changed from ncsa to main
-      - add-dockerfile
+      - main
 
 jobs:
   # Only runs on manual workflow_dispatch
@@ -71,7 +70,7 @@ jobs:
   # Get current version for main and add-dockerfile branch builds
   get-current-version:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'add-dockerfile')
+    if: github.event_name == 'push' && (github.ref_name == 'main')
     outputs:
       VERSION: ${{ steps.get_version.outputs.version }}
       VERSION_TAG: ${{ steps.get_version.outputs.version_tag }}
@@ -130,7 +129,7 @@ jobs:
           draft: false
           prerelease: false
 
-  # Runs on: manual dispatch with publish=true OR push to main OR push to add-dockerfile
+  # Runs on: manual dispatch with publish=true OR push to main
   build-and-push-docker:
     runs-on: ubuntu-latest
     permissions:
@@ -138,7 +137,7 @@ jobs:
       packages: write
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') ||
-      (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'add-dockerfile'))
+      (github.event_name == 'push' && (github.ref_name == 'main'))
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
For this pull request, one change was made to a github action.

Before, an image was built and pushed on pushes to main or add-dockerfile branch, but the other branch has been merged in. So that part of the action was taken out. 