### PR TITLE
helm chart to deploy on kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM python:3.12-slim
 
+# Example build:
+# docker build -t ghcr.io/permafrostdiscoverygateway/water-timeseries-v2:0.9.4 .
+
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     make \
     curl \
     cmake \
+    rustc \
+    cargo \
     git \
     pkg-config \
     libgdal-dev \
@@ -41,3 +46,10 @@ ENV VIRTUAL_ENV=/app/.venv
 # Remove the fixed ENTRYPOINT - we'll specify commands at runtime
 # Keep CMD as default for local testing, but it can be overridden
 CMD ["uv", "run", "water-timeseries"]
+
+# metadata
+LABEL org.opencontainers.image.title="water-timeseries-v2"
+LABEL org.opencontainers.image.description="Streamlit app for exploring water timeseries data for changing Arctic lakes."
+LABEL org.opencontainers.image.source="https://github.com/PermafrostDiscoveryGateway/water-timeseries-v2"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL maintainer="PDG <https://github.com/PermafrostDiscoveryGateway>"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,54 @@
+Apache License
+Version 2.0, January 2004
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined in Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original Work and any Derivative Works thereof, that is intentionally submitted to, processed by, and received by Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You by that entity under this License for the Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions of this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contribution.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of Your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: water-timeseries
+description: Helm chart for the Water Timeseries Streamlit dashboard
+sources:
+  - https://github.com/PermafrostDiscoveryGateway/water-timeseries-v2
+type: application
+version: 0.9.4
+appVersion: "0.9.4"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "water-timeseries.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "water-timeseries.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "water-timeseries.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "water-timeseries.labels" -}}
+helm.sh/chart: {{ include "water-timeseries.chart" . }}
+{{ include "water-timeseries.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "water-timeseries.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "water-timeseries.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "water-timeseries.fullname" . }}
+  labels:
+    {{- include "water-timeseries.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "water-timeseries.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "water-timeseries.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if gt (len .Values.podAnnotations) 0 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: water-timeseries
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          command:
+            - streamlit
+          args:
+            - run
+            - src/water_timeseries/dashboard/app.py
+            - --server.port={{ .Values.dashboard.port }}
+            - --server.address=0.0.0.0
+            - --
+            - --vector-file
+            - {{ .Values.dashboard.vectorFile | quote }}
+            - --dw-dataset-file
+            - {{ .Values.dashboard.dwDatasetFile | quote }}
+            - --jrc-dataset-file
+            - {{ .Values.dashboard.jrcDatasetFile | quote }}
+            - --precomputed-nrt-dir
+            - {{ .Values.dashboard.precomputedNrtDir | quote }}
+            - --dw-start-year={{ .Values.dashboard.dwStartYear }}
+            - --dw-end-year={{ .Values.dashboard.dwEndYear }}
+            - --dw-start-month={{ .Values.dashboard.dwStartMonth }}
+            - --dw-end-month={{ .Values.dashboard.dwEndMonth }}
+            - --viz-configuration={{ .Values.dashboard.vizConfiguration }}
+            {{- if .Values.dashboard.offlineMode }}
+            - --offline-mode
+            {{- end }}
+            {{- if .Values.dashboard.eeProject }}
+            - --ee-project={{ .Values.dashboard.eeProject }}
+            {{- end }}
+          env:
+            - name: MPLBACKEND
+              value: Agg
+            {{- if .Values.dashboard.eeProject }}
+            - name: EE_PROJECT
+              value: {{ .Values.dashboard.eeProject | quote }}
+            {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath | quote }}
+              readOnly: true
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ default (include "water-timeseries.fullname" .) .Values.persistence.existingClaim | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "water-timeseries.fullname" . }}
+  labels:
+    {{- include "water-timeseries.labels" . | nindent 4 }}
+  {{- if gt (len .Values.ingress.annotations) 0 }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingress.host }}
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "water-timeseries.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+    {{- else }}
+    - http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "water-timeseries.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "water-timeseries.fullname" . }}
+  labels:
+    {{- include "water-timeseries.labels" . | nindent 4 }}
+  {{- if gt (len .Values.persistence.annotations) 0 }}
+  annotations:
+    {{- toYaml .Values.persistence.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "water-timeseries.fullname" . }}
+  labels:
+    {{- include "water-timeseries.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "water-timeseries.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,57 @@
+replicaCount: 1
+
+image:
+  repository: water-timeseries-v2
+  tag: 0.9.4
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+dashboard:
+  port: 8501
+  offlineMode: false
+  eeProject: ""
+  vectorFile: /data/input/lake_polygons.parquet
+  dwDatasetFile: /data/input/lakes_dw_test.zarr
+  jrcDatasetFile: /data/input/lakes_jrc_test.zarr
+  precomputedNrtDir: /data/nrt
+  vizConfiguration: colored_historical
+  dwStartYear: 2017
+  dwEndYear: 2025
+  dwStartMonth: 6
+  dwEndMonth: 9
+
+persistence:
+  enabled: true
+  existingClaim: "local-data-pvc"
+  mountPath: /data
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  storageClassName: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 8501
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+  host: water-timeseries.localhost
+  path: /
+  pathType: Prefix
+  tls: []
+
+resources: {}
+
+podAnnotations: {}
+podLabels: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "water-timeseries"
 version = "0.9.3"
 description = "Toolbox to download, analyze, and visualize water area time-series"
 readme = "README.md"
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Ingmar Nitze", email = "ingmarnitze@gmail.com" }
 ]


### PR DESCRIPTION
Also added image metadata, and LICENSE.

Still needs work to sync version tags and help deployment files, needs discussion with @initze -- I'm just creating a draft PR so people can easily see the changes.

The helm chart would target a specific published image version from GHCR, but it looks like the current repository publishes images under a generic `latest` tag, rather than a specific version tag like `0.9.3` or `0.10.0`. The help chart needs to reference a specific packages release, with a tag like `ghcr.io/permafrostdiscoverygateway/water-timeseries-v2:0.10.0`. To be discussed.