### PR TITLE
External input files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       - ${PRECOMPUTED_NRT_DIR:-downloads/nrt}
       - --pmtiles-file
       - ${PMTILES_FILE:-downloads/tiles/lake_polygons.pmtiles}
+      - --pmtiles-url
+      - ${PMTILES_URL:-}
       - --viz-configuration
       - ${VIZ_CONFIGURATION:-colored_historical}
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,8 @@ services:
       - ${DOWNLOADS_DIR:-./downloads}:/app/downloads:ro
       # Optional: host EE credentials (alternative to EARTHENGINE_TOKEN in .env)
       - ${EARTHENGINE_CREDENTIALS_DIR:-${HOME}/.config/earthengine}:/root/.config/earthengine:ro
+      # Host GCloud Application Default Credentials (ADC)
+      - ${HOME}/.config/gcloud:/root/.config/gcloud:ro
     ports:
       - "8501:8501"
       # PMTiles tile server - the browser fetches tiles directly from this port.
@@ -44,6 +46,7 @@ services:
       MPLBACKEND: Agg
       EE_PROJECT: ${EE_PROJECT:-}
       EARTHENGINE_TOKEN: ${EARTHENGINE_TOKEN:-}
+      GOOGLE_APPLICATION_CREDENTIALS: /root/.config/gcloud/application_default_credentials.json
       # PMTiles tile server: bind on a fixed port so Docker can publish it,
       # and tell the browser to reach it via localhost (the published port).
       PMTILES_PORT: "8502"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ dependencies = [
     "tippecanoe>=2.72.0",
     "leafmap>=0.62.0",
     "pygeohash>=3.3.0",
+    "gcsfs",
+    "h5py",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     # "xarray>=2023.0.0",
     "tqdm",
     "netcdf4",
-    "python-geohash",
     "seaborn",
     "matplotlib>=3.8.0",
     "shapely",

--- a/src/water_timeseries/dashboard/app.py
+++ b/src/water_timeseries/dashboard/app.py
@@ -186,6 +186,9 @@ def main(
     if viz_configuration is None:
         viz_configuration = "colored_historical"
 
+    if pmtiles_url == "":
+        pmtiles_url = None
+
     create_app(
         data_path=vector_file,
         zarr_path=dw_dataset_file,

--- a/src/water_timeseries/dashboard/app.py
+++ b/src/water_timeseries/dashboard/app.py
@@ -148,23 +148,28 @@ def main(
     default_jrc_dataset_file = _REPO_ROOT / "tests" / "data" / "lakes_jrc_test.zarr"
 
     # Validate provided file paths and fall back to defaults if they don't exist
+    from water_timeseries.utils.io import is_remote_path
+
     if vector_file is not None:
-        path = Path(vector_file)
-        if not path.exists():
-            warnings.warn(f"Vector file not found: {vector_file}. Falling back to default test data.")
-            vector_file = None
+        if not is_remote_path(vector_file):
+            path = Path(vector_file)
+            if not path.exists():
+                warnings.warn(f"Vector file not found: {vector_file}. Falling back to default test data.")
+                vector_file = None
 
     if dw_dataset_file is not None:
-        path = Path(dw_dataset_file)
-        if not path.exists():
-            warnings.warn(f"DW dataset file not found: {dw_dataset_file}. Falling back to default test data.")
-            dw_dataset_file = None
+        if not is_remote_path(dw_dataset_file):
+            path = Path(dw_dataset_file)
+            if not path.exists():
+                warnings.warn(f"DW dataset file not found: {dw_dataset_file}. Falling back to default test data.")
+                dw_dataset_file = None
 
     if jrc_dataset_file is not None:
-        path = Path(jrc_dataset_file)
-        if not path.exists():
-            warnings.warn(f"JRC dataset file not found: {jrc_dataset_file}. Falling back to default test data.")
-            jrc_dataset_file = None
+        if not is_remote_path(jrc_dataset_file):
+            path = Path(jrc_dataset_file)
+            if not path.exists():
+                warnings.warn(f"JRC dataset file not found: {jrc_dataset_file}. Falling back to default test data.")
+                jrc_dataset_file = None
 
     # Use provided paths or defaults
     if vector_file is None:

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -851,36 +851,121 @@ def _load_precomputed_nrt(
         return None, None
 
     from loguru import logger
+    from water_timeseries.utils.io import is_remote_path
+    import fsspec
 
-    nrt_dir = Path(precomputed_nrt_dir)
-    counts_path = nrt_dir / "nrt_monthly_drain_counts.parquet"
-    breaks_path = nrt_dir / "nrt_monthly_drain_breaks.parquet"
+    path_str = str(precomputed_nrt_dir)
+    is_remote = is_remote_path(path_str)
 
     counts_df: Optional[pd.DataFrame] = None
     breaks_df: Optional[pd.DataFrame] = None
 
-    if counts_path.exists():
-        counts_df = pd.read_parquet(counts_path)
+    if path_str.endswith(".parquet"):
+        try:
+            logger.info(f"Loading single pre-computed breaks file from {path_str}")
+            breaks_df = pd.read_parquet(path_str)
+            
+            # Ensure "analysis_month" column exists if missing
+            if "analysis_month" not in breaks_df.columns:
+                if "date" in breaks_df.columns:
+                    breaks_df["analysis_month"] = pd.to_datetime(breaks_df["date"]).dt.strftime("%Y-%m")
+                elif "date_break" in breaks_df.columns:
+                    breaks_df["analysis_month"] = pd.to_datetime(breaks_df["date_break"]).dt.strftime("%Y-%m")
+                else:
+                    breaks_df["analysis_month"] = "2026-06" # Default fallback
+            
+            if "id_geohash" not in breaks_df.columns and breaks_df.index.name == "id_geohash":
+                breaks_df = breaks_df.reset_index()
+            
+            if "analysis_month" in breaks_df.columns:
+                counts_df = breaks_df.groupby("analysis_month").size().reset_index(name="drained_lake_count")
+            
+            return counts_df, breaks_df
+        except Exception as e:
+            logger.error(f"Failed to load single pre-computed breaks file: {e}")
+            return None, None
 
-    if breaks_path.exists():
-        breaks_df = pd.read_parquet(breaks_path)
+    # Handle directory loading (local or remote)
+    if is_remote:
+        # Use fsspec for remote directory paths
+        try:
+            counts_url = path_str.rstrip("/") + "/nrt_monthly_drain_counts.parquet"
+            breaks_url = path_str.rstrip("/") + "/nrt_monthly_drain_breaks.parquet"
+            
+            fs_counts, counts_path_fs = fsspec.core.url_to_fs(counts_url)
+            if fs_counts.exists(counts_path_fs):
+                counts_df = pd.read_parquet(counts_url)
+                
+            fs_breaks, breaks_path_fs = fsspec.core.url_to_fs(breaks_url)
+            if fs_breaks.exists(breaks_path_fs):
+                breaks_df = pd.read_parquet(breaks_url)
+                
+            if breaks_df is None:
+                # Try to list files in directory
+                fs_dir, dir_path_fs = fsspec.core.url_to_fs(path_str)
+                # List files matching nrt_*_drain_breaks.parquet
+                all_files = fs_dir.ls(dir_path_fs)
+                monthly_files = []
+                for f_path in all_files:
+                    name = f_path.split("/")[-1]
+                    if name.startswith("nrt_") and name.endswith("_drain_breaks.parquet"):
+                        # Reconstruct full URL/path
+                        full_path = path_str.rstrip("/") + "/" + name
+                        monthly_files.append(full_path)
+                
+                monthly_files = sorted(monthly_files)
+                if monthly_files:
+                    logger.info(f"Found {len(monthly_files)} remote NRT monthly files, aggregating...")
+                    dfs = []
+                    for file_path in monthly_files:
+                        try:
+                            df = pd.read_parquet(file_path)
+                            if not df.empty:
+                                dfs.append(df)
+                        except Exception as e:
+                            logger.warning(f"Failed to read {file_path}: {e}")
+                    if dfs:
+                        breaks_df = pd.concat(dfs, ignore_index=True)
+        except Exception as e:
+            logger.error(f"Failed to load pre-computed NRT from remote directory {path_str}: {e}")
+    else:
+        nrt_dir = Path(precomputed_nrt_dir)
+        counts_path = nrt_dir / "nrt_monthly_drain_counts.parquet"
+        breaks_path = nrt_dir / "nrt_monthly_drain_breaks.parquet"
 
-    if breaks_df is None:
-        monthly_files = sorted(list(nrt_dir.glob("nrt_*_drain_breaks.parquet")))
-        if monthly_files:
-            logger.info(f"Found {len(monthly_files)} individual NRT monthly files, aggregating...")
-            dfs = []
-            for file_path in monthly_files:
-                try:
-                    df = pd.read_parquet(file_path)
-                    if not df.empty:
-                        dfs.append(df)
-                except Exception as e:
-                    logger.warning(f"Failed to read {file_path}: {e}")
-            if dfs:
-                breaks_df = pd.concat(dfs, ignore_index=True)
+        if counts_path.exists():
+            counts_df = pd.read_parquet(counts_path)
+
+        if breaks_path.exists():
+            breaks_df = pd.read_parquet(breaks_path)
+
+        if breaks_df is None:
+            monthly_files = sorted(list(nrt_dir.glob("nrt_*_drain_breaks.parquet")))
+            if monthly_files:
+                logger.info(f"Found {len(monthly_files)} individual NRT monthly files, aggregating...")
+                dfs = []
+                for file_path in monthly_files:
+                    try:
+                        df = pd.read_parquet(file_path)
+                        if not df.empty:
+                            dfs.append(df)
+                    except Exception as e:
+                        logger.warning(f"Failed to read {file_path}: {e}")
+                if dfs:
+                    breaks_df = pd.concat(dfs, ignore_index=True)
 
     if counts_df is None and breaks_df is not None and not breaks_df.empty:
+        # Standardize index
+        if "id_geohash" not in breaks_df.columns and breaks_df.index.name == "id_geohash":
+            breaks_df = breaks_df.reset_index()
+            
+        # Ensure analysis_month exists
+        if "analysis_month" not in breaks_df.columns:
+            if "date" in breaks_df.columns:
+                breaks_df["analysis_month"] = pd.to_datetime(breaks_df["date"]).dt.strftime("%Y-%m")
+            elif "date_break" in breaks_df.columns:
+                breaks_df["analysis_month"] = pd.to_datetime(breaks_df["date_break"]).dt.strftime("%Y-%m")
+                
         if "analysis_month" in breaks_df.columns:
             counts_df = breaks_df.groupby("analysis_month").size().reset_index(name="drained_lake_count")
 

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -850,9 +850,10 @@ def _load_precomputed_nrt(
     if precomputed_nrt_dir is None:
         return None, None
 
-    from loguru import logger
-    from water_timeseries.utils.io import is_remote_path
     import fsspec
+    from loguru import logger
+
+    from water_timeseries.utils.io import is_remote_path
 
     path_str = str(precomputed_nrt_dir)
     is_remote = is_remote_path(path_str)

--- a/src/water_timeseries/dashboard/pmtiles_viewer.py
+++ b/src/water_timeseries/dashboard/pmtiles_viewer.py
@@ -10,7 +10,7 @@ import geopandas as gpd
 import streamlit as st
 
 from water_timeseries.utils.io import load_vector_dataset
-from water_timeseries.utils.pmtiles_reader import read_pmtiles_header
+from water_timeseries.utils.pmtiles_reader import read_pmtiles_header, read_pmtiles_header_remote
 from water_timeseries.utils.pmtiles_serve import _MAP_HTML, PmtilesServer
 
 _SESSION_SERVER_KEY = "_pmtiles_map_server"
@@ -55,11 +55,14 @@ def _bounds_center_zoom(gdf: gpd.GeoDataFrame) -> tuple[list[float], float]:
     return center, zoom
 
 
-def _get_or_start_server(pmtiles_file: Path | str) -> PmtilesServer:
-    """Start (or reuse) a local server that hosts both the map page and .pmtiles file."""
-    pmtiles_path = Path(pmtiles_file).resolve()
-    if not pmtiles_path.is_file():
-        raise FileNotFoundError(f"PMTiles file not found: {pmtiles_path}")
+def _get_or_start_server(pmtiles_file: Optional[Path | str] = None) -> PmtilesServer:
+    """Start (or reuse) a local server that hosts the map page (and optionally the .pmtiles file)."""
+    if pmtiles_file is not None:
+        pmtiles_path = Path(pmtiles_file).resolve()
+        if not pmtiles_path.is_file():
+            raise FileNotFoundError(f"PMTiles file not found: {pmtiles_path}")
+    else:
+        pmtiles_path = None
 
     server: Optional[PmtilesServer] = st.session_state.get(_SESSION_SERVER_KEY)
     if server is None or server.pmtiles_path != pmtiles_path:
@@ -95,6 +98,17 @@ def _build_map_config(
             center = header["center"]
         if zoom is None:
             zoom = float(header["zoom"])
+    elif bounds is None and pmtiles_url:
+        try:
+            header = read_pmtiles_header_remote(pmtiles_url)
+            bounds = header["bounds"]
+            if center is None:
+                center = header["center"]
+            if zoom is None:
+                zoom = float(header["zoom"])
+        except Exception as e:
+            print(f"Could not fetch remote PMTiles header: {e}")
+            # Fall back to hardcoded Alaska defaults
     elif bounds is None and vector_file_for_bounds is not None:
         gdf = load_vector_dataset(vector_file_for_bounds)
         if gdf.crs is None:
@@ -143,10 +157,10 @@ def render_pmtiles_map(
     fetches to a separate tile port (basemap loads, vector lakes do not).
     """
     if pmtiles_url and not pmtiles_file:
+        server = _get_or_start_server(None)  # Server running in HTML-only remote mode
         config = _build_map_config(
             pmtiles_url=pmtiles_url,
             vector_file_for_bounds=vector_file_for_bounds,
-            pmtiles_file=None,
             id_column=id_column,
             viz_configuration=viz_configuration,
             height=height,
@@ -155,15 +169,14 @@ def render_pmtiles_map(
             drained_data=drained_data,
             show_main_layer=show_main_layer,
         )
-        st.warning(
-            "Remote PMTiles URL without a local file: embed mode may still hit browser "
-            "restrictions. Prefer --pmtiles-file for local development."
-        )
+        map_url = server.map_iframe_url(config)
         _inject_selection_bridge()
-        import streamlit.components.v1 as components
-
-        html = _MAP_HTML.read_text(encoding="utf-8").replace("__CONFIG_JSON__", json.dumps(config))
-        components.html(html, height=height)
+        
+        if hasattr(st, "iframe"):
+            st.iframe(map_url, height=height)
+        else:
+            import streamlit.components.v1 as components
+            components.iframe(map_url, height=height)
         return
 
     if pmtiles_file is None:

--- a/src/water_timeseries/dashboard/pmtiles_viewer.py
+++ b/src/water_timeseries/dashboard/pmtiles_viewer.py
@@ -155,7 +155,7 @@ def render_pmtiles_map(
     share one origin. Streamlit's ``components.html`` sandbox often blocks cross-origin
     fetches to a separate tile port (basemap loads, vector lakes do not).
     """
-    if pmtiles_url and not pmtiles_file:
+    if pmtiles_url:
         server = _get_or_start_server(None)  # Server running in HTML-only remote mode
         config = _build_map_config(
             pmtiles_url=pmtiles_url,

--- a/src/water_timeseries/dashboard/pmtiles_viewer.py
+++ b/src/water_timeseries/dashboard/pmtiles_viewer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Optional
 
@@ -11,7 +10,7 @@ import streamlit as st
 
 from water_timeseries.utils.io import load_vector_dataset
 from water_timeseries.utils.pmtiles_reader import read_pmtiles_header, read_pmtiles_header_remote
-from water_timeseries.utils.pmtiles_serve import _MAP_HTML, PmtilesServer
+from water_timeseries.utils.pmtiles_serve import PmtilesServer
 
 _SESSION_SERVER_KEY = "_pmtiles_map_server"
 

--- a/src/water_timeseries/utils/io.py
+++ b/src/water_timeseries/utils/io.py
@@ -8,6 +8,14 @@ import xarray as xr
 from loguru import logger as logger
 
 
+def is_remote_path(path: Union[str, Path]) -> bool:
+    """Check if path is a remote URL/URI (e.g. gs://, s3://, http://, https://)."""
+    if isinstance(path, Path):
+        return False
+    path_str = str(path)
+    return any(path_str.startswith(proto) for proto in ("gs://", "s3://", "http://", "https://"))
+
+
 def load_vector_dataset(
     file_path: Union[str, Path],
     logger: Optional[logger] = None,
@@ -26,23 +34,29 @@ def load_vector_dataset(
     Raises:
         FileNotFoundError: If the file does not exist.
     """
-    file_path = Path(file_path)
+    file_path_str = str(file_path)
+    is_remote = is_remote_path(file_path_str)
 
-    if not file_path.exists():
-        if logger:
-            logger.warning(f"Vector dataset file not found: {file_path}")
-        raise FileNotFoundError(f"Vector dataset file not found: {file_path}")
-
-    suffix = file_path.suffix.lower()
+    if is_remote:
+        # Determine suffix from remote string path
+        clean_path = file_path_str.split("?")[0].split("#")[0]
+        suffix = "." + clean_path.split(".")[-1].lower() if "." in clean_path else ""
+    else:
+        file_path = Path(file_path)
+        if not file_path.exists():
+            if logger:
+                logger.warning(f"Vector dataset file not found: {file_path}")
+            raise FileNotFoundError(f"Vector dataset file not found: {file_path}")
+        suffix = file_path.suffix.lower()
 
     if logger:
-        logger.info(f"Loading vector dataset from {file_path}")
+        logger.info(f"Loading vector dataset from {file_path_str}")
 
     # GeoPackage, Shapefile, GeoJSON formats
     if suffix in [".gpkg", ".shp", ".geojson", ".gjson"]:
-        vector_ds = gpd.read_file(file_path)
+        vector_ds = gpd.read_file(file_path_str if is_remote else file_path)
     elif suffix in [".parquet"]:
-        vector_ds = gpd.read_parquet(file_path)
+        vector_ds = gpd.read_parquet(file_path_str if is_remote else file_path)
     else:
         if logger:
             logger.warning(f"Unsupported vector file format: {suffix}")
@@ -120,6 +134,7 @@ def save_xarray_dataset(
 def load_xarray_dataset(
     path: Union[str, Path],
     format: Optional[str] = None,
+    **kwargs,
 ) -> xr.Dataset:
     """Load xarray dataset from file.
 
@@ -127,6 +142,7 @@ def load_xarray_dataset(
         path: Path to the dataset file.
         format: Format of the file ('zarr' or 'netcdf'). If None, auto-detected
             from extension.
+        **kwargs: Additional arguments passed to xr.open_zarr or xr.open_dataset.
 
     Returns:
         xr.Dataset: The loaded dataset.
@@ -134,20 +150,35 @@ def load_xarray_dataset(
     Raises:
         ValueError: If the file format is not supported.
     """
-    path = Path(path)
+    path_str = str(path)
+    is_remote = is_remote_path(path_str)
 
     if format is None:
-        ext = path.suffix.lower()
+        if is_remote:
+            clean_path = path_str.split("?")[0].split("#")[0]
+            ext = "." + clean_path.split(".")[-1].lower() if "." in clean_path else ""
+            if clean_path.endswith(".zarr/"):
+                ext = ".zarr"
+        else:
+            ext = Path(path).suffix.lower()
+
         if ext == ".zarr":
             format = "zarr"
-        elif ext == ".nc":
+        elif ext in (".nc", ".ncin"):
             format = "netcdf"
         else:
             raise ValueError(f"Cannot auto-detect format for extension: {ext}")
 
+    target_path = path_str if is_remote else Path(path)
+
     if format == "zarr":
-        return xr.open_zarr(path)
+        return xr.open_zarr(target_path, **kwargs)
     elif format == "netcdf":
-        return xr.open_dataset(path)
+        if is_remote:
+            import fsspec
+            f = fsspec.open(target_path)
+            return xr.open_dataset(f.open(), **kwargs)
+        else:
+            return xr.open_dataset(target_path, **kwargs)
     else:
         raise ValueError(f"Unsupported format: {format}. Use 'zarr' or 'netcdf'.")

--- a/src/water_timeseries/utils/pmtiles_reader.py
+++ b/src/water_timeseries/utils/pmtiles_reader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import struct
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -15,11 +16,46 @@ def read_pmtiles_header(path: Path | str) -> dict[str, Any]:
     path = Path(path)
     with path.open("rb") as fh:
         header = fh.read(127)
-    if len(header) != 127 or header[:7] != b"PMTiles":
+    if len(header) < 127 or header[:7] != b"PMTiles":
         raise ValueError(f"Not a PMTiles v3 file: {path}")
     if header[7] != 0x3:
         raise ValueError(f"Unsupported PMTiles version byte: {header[7]}")
 
+    min_zoom = header[100]
+    max_zoom = header[101]
+    min_lon_e7, min_lat_e7, max_lon_e7, max_lat_e7 = struct.unpack_from("<iiii", header, 102)
+    center_zoom = header[118]
+    center_lon_e7, center_lat_e7 = struct.unpack_from("<ii", header, 119)
+
+    e7 = 1e7
+    min_lon, min_lat = min_lon_e7 / e7, min_lat_e7 / e7
+    max_lon, max_lat = max_lon_e7 / e7, max_lat_e7 / e7
+    center_lon, center_lat = center_lon_e7 / e7, center_lat_e7 / e7
+
+    return {
+        "min_zoom": min_zoom,
+        "max_zoom": max_zoom,
+        "center_zoom": center_zoom,
+        "bounds": [[min_lon, min_lat], [max_lon, max_lat]],
+        "center": [center_lon, center_lat],
+        "zoom": center_zoom if center_zoom else max(2, min_zoom),
+    }
+
+
+def read_pmtiles_header_remote(url: str) -> dict[str, Any]:
+    """Fetch PMTiles header from a remote URL using a range request."""
+    # Request bytes 0 through 126 (which is exactly 127 bytes)
+    req = urllib.request.Request(url, headers={"Range": "bytes=0-126"})
+    with urllib.request.urlopen(req) as resp:
+        header = resp.read()
+        
+    if len(header) < 127 or header[:7] != b"PMTiles":
+        raise ValueError(f"Not a valid PMTiles v3 remote URL: {url}")
+
+    # Ensure we only process the first 127 bytes in case a server sends more
+    header = header[:127]
+
+    # PMTiles v3 header layout uses Int32 scaled by 1e7 starting at byte 102
     min_zoom = header[100]
     max_zoom = header[101]
     min_lon_e7, min_lat_e7, max_lon_e7, max_lat_e7 = struct.unpack_from("<iiii", header, 102)

--- a/src/water_timeseries/utils/pmtiles_serve.py
+++ b/src/water_timeseries/utils/pmtiles_serve.py
@@ -56,8 +56,10 @@ class _PmtilesHTTPRequestHandler(BaseHTTPRequestHandler):
             self.send_error(400, "Missing config or config_id query parameter")
             return
 
-        pmtiles_name = self.server.pmtiles_filename  # type: ignore[attr-defined]
-        config["pmtiles_url"] = f"{self.server.base_url}/{pmtiles_name}"  # type: ignore[attr-defined]
+        # Only modify the pmtiles_url if we're actually serving a local file
+        pmtiles_name = getattr(self.server, "pmtiles_filename", None)
+        if pmtiles_name:
+            config["pmtiles_url"] = f"{self.server.base_url}/{pmtiles_name}"  # type: ignore[attr-defined]
 
         template = _MAP_HTML.read_text(encoding="utf-8")
         html = template.replace("__CONFIG_JSON__", json.dumps(config))
@@ -89,6 +91,11 @@ class _PmtilesHTTPRequestHandler(BaseHTTPRequestHandler):
 
     def _serve_file(self, rel_path: str, head_only: bool = False) -> None:
         if not rel_path:
+            self.send_error(404, "Not found")
+            return
+
+        # In HTML-only remote URL mode, the server won't have a static file directory mapped.
+        if not getattr(self.server, "directory", None):
             self.send_error(404, "Not found")
             return
 
@@ -140,14 +147,20 @@ class PmtilesServer:
 
     def __init__(
         self,
-        pmtiles_file: Path | str,
+        pmtiles_file: Optional[Path | str] = None,
         host: str = "0.0.0.0",
         port: int = 0,
         public_host: Optional[str] = None,
     ):
-        self.pmtiles_path = Path(pmtiles_file).resolve()
-        self.directory = self.pmtiles_path.parent
-        self.pmtiles_filename = self.pmtiles_path.name
+        if pmtiles_file is not None:
+            self.pmtiles_path = Path(pmtiles_file).resolve()
+            self.directory = self.pmtiles_path.parent
+            self.pmtiles_filename = self.pmtiles_path.name
+        else:
+            self.pmtiles_path = None
+            self.directory = _MAP_HTML.parent # Fallback map location
+            self.pmtiles_filename = None
+
         self.host = host
         # Allow fixed port via env var (required for Docker port publishing).
         # Default 0 = OS picks a random free port (works for local uv runs).


### PR DESCRIPTION
1. **Remote Path Identification (`is_remote_path`)**:
   - Added a helper utility in [io.py](file:///Users/drshika2/water-timeseries-v2/src/water_timeseries/utils/io.py) to detect remote URIs (`gs://`, `s3://`, `http://`, `https://`).

2. **Bypass Local Checks for Remote Sources**:
   - **Vector Loading**: Updated [load_vector_dataset](file:///Users/drshika2/water-timeseries-v2/src/water_timeseries/utils/io.py) to skip local existence check and `Path` conversions when the URI is remote, delegating remote reads directly to GeoPandas.
   - **Xarray Loading**: Updated [load_xarray_dataset](file:///Users/drshika2/water-timeseries-v2/src/water_timeseries/utils/io.py) to accept `**kwargs`, open remote Zarr directly, and open remote NetCDF dynamically using `fsspec` + `h5netcdf` streams.
   - **App Validation**: Updated the dashboard validation in [app.py](file:///Users/drshika2/water-timeseries-v2/src/water_timeseries/dashboard/app.py) to skip the local `.exists()` warnings/fallbacks for remote URIs.

3. **Remote/Single Parquet Breaks Support**:
   - Modified `_load_precomputed_nrt` in [map_viewer.py](file:///Users/drshika2/water-timeseries-v2/src/water_timeseries/dashboard/map_viewer.py) to support loading a single parquet file (local or remote) directly instead of requiring a directory.
   - Added dynamic derivation of the `analysis_month` column from `date` or `date_break` columns if it is missing from the breaks file.
   - Handled standardizing `id_geohash` when stored as index in the parquet datasets.
   
How to run:
1. Be authenticated with Google Cloud
2. Add file URLs or URLs to .env:
```
VECTOR_FILE=gs://pdg-storage-default/workflows_optimization/lake_change_detection/filtered_full_set_v2.parquet
DW_DATASET_FILE=gs://pdg-storage-default/workflows_optimization/lake_change_detection/lakes_dw_V2d_2016-2025_gapfilled_chunked_v2.zarr
PRECOMPUTED_NRT_DIR=gs://pdg-storage-default/workflows_optimization/lake_change_detection/output_samples/DW_2026-06_-150_-145_60_62_breaks.parquet
PMTILES_URL=https://arcticdata.io/data/tiles/10.18739/lakeDrainage/pmtiles/lakes.pmtiles

```
3. run `docker compose up --build`