### PR TITLE
Fix PMTiles multi-session conflict & broken dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     # "xarray>=2023.0.0",
     "tqdm",
     "netcdf4",
-    "python-geohash",
     "seaborn",
     "matplotlib>=3.8.0",
     "shapely",

--- a/src/water_timeseries/dashboard/pmtiles_viewer.py
+++ b/src/water_timeseries/dashboard/pmtiles_viewer.py
@@ -55,20 +55,14 @@ def _bounds_center_zoom(gdf: gpd.GeoDataFrame) -> tuple[list[float], float]:
     return center, zoom
 
 
-def _get_or_start_server(pmtiles_file: Path | str) -> PmtilesServer:
-    """Start (or reuse) a local server that hosts both the map page and .pmtiles file."""
+@st.cache_resource
+def _get_or_start_server(pmtiles_file: str) -> PmtilesServer:
+    """Start (or reuse) a global server that hosts both the map page and .pmtiles file."""
     pmtiles_path = Path(pmtiles_file).resolve()
     if not pmtiles_path.is_file():
         raise FileNotFoundError(f"PMTiles file not found: {pmtiles_path}")
 
-    server: Optional[PmtilesServer] = st.session_state.get(_SESSION_SERVER_KEY)
-    if server is None or server.pmtiles_path != pmtiles_path:
-        if server is not None:
-            server.stop()
-        server = PmtilesServer(pmtiles_path).start()
-        st.session_state[_SESSION_SERVER_KEY] = server
-
-    return server
+    return PmtilesServer(pmtiles_path).start()
 
 
 def _build_map_config(
@@ -169,7 +163,7 @@ def render_pmtiles_map(
     if pmtiles_file is None:
         raise ValueError("Either pmtiles_file or pmtiles_url must be provided")
 
-    server = _get_or_start_server(pmtiles_file)
+    server = _get_or_start_server(str(pmtiles_file))
     config = _build_map_config(
         pmtiles_file=pmtiles_file,
         vector_file_for_bounds=vector_file_for_bounds if pmtiles_file is None else None,


### PR DESCRIPTION
- **Dashboard Server Fix:** Updated the PMTiles background server to use Streamlit's `@st.cache_resource` instead of `st.session_state`. This ensures a single global server instance is shared across all users/browser tabs, preventing "address already in use" port conflicts.
- **Dependency Fix:** Removed the outdated `python-geohash` dependency from `pyproject.toml` to fix local build errors, as the codebase already uses the pure-Python `pygeohash` package instead.