### PR TITLE
Add dynamic NRT drainage year styling and sidebar style menu

### DIFF
--- a/src/water_timeseries/dashboard/app.py
+++ b/src/water_timeseries/dashboard/app.py
@@ -151,16 +151,6 @@ def parse_args():
         help="End month for Dynamic World time series (inclusive). Default is 9.",
     )
     parser.add_argument(
-        "--viz-configuration",
-        type=str,
-        default="colored_historical",
-        help=(
-            "Visualization configuration name for the map viewer. "
-            "Options include 'colored_historical' (default) and 'drainage_year'. "
-            "This controls the styling and color scheme of the map layers."
-        ),
-    )
-    parser.add_argument(
         "--pmtiles-file",
         type=str,
         default=None,
@@ -196,7 +186,6 @@ def main(
     precomputed_nrt_dir: str | Path = None,
     offline_mode: bool = False,
     ee_project: str = None,
-    viz_configuration: str = None,
     pmtiles_file: str | Path = None,
     pmtiles_url: str = None,
     dw_start_year: int = None,
@@ -215,7 +204,6 @@ def main(
         precomputed_nrt_dir: Directory with pre-computed NRT parquet files.
             Auto-detected from ``precomputed/nrt/`` in the repo root when present.
         offline_mode: If True, disables Google Earth Engine download functionality.
-        viz_configuration: The visualization configuration name for the map viewer.
         verbose: Verbosity level for logging.
     """
     setup_logging(logfile=logfile, verbose=verbose)
@@ -261,9 +249,6 @@ def main(
     if precomputed_nrt_dir is None:
         precomputed_nrt_dir = _resolve_default_nrt_dir()
 
-    if viz_configuration is None:
-        viz_configuration = "colored_historical"
-
     if pmtiles_url == "":
         pmtiles_url = None
 
@@ -278,7 +263,6 @@ def main(
         dw_end_year=dw_end_year,
         dw_start_month=dw_start_month,
         dw_end_month=dw_end_month,
-        viz_configuration_name=viz_configuration,
         pmtiles_file=pmtiles_file,
         pmtiles_url=pmtiles_url,
     )
@@ -297,7 +281,6 @@ if __name__ == "__main__":
         dw_end_year=args.dw_end_year,
         dw_start_month=args.dw_start_month,
         dw_end_month=args.dw_end_month,
-        viz_configuration=args.viz_configuration,
         pmtiles_file=args.pmtiles_file,
         pmtiles_url=args.pmtiles_url,
         logfile=args.logfile,

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -334,6 +334,15 @@ class MapViewer:
             drained_ids = list(self.drained_data.keys())
             logger.info(f"Drained data overlay: {len(drained_ids) if drained_ids else 0} lakes")
             logger.info("Setting up map")
+            
+        all_drainage_years = None
+        if viz_configuration_name == "drainage_year":
+            nrt_breaks = st.session_state.get("precomputed_nrt_breaks")
+            if nrt_breaks is not None and "analysis_month" in nrt_breaks.columns and "id_geohash" in nrt_breaks.columns:
+                years_df = nrt_breaks[["id_geohash", "analysis_month"]].copy()
+                years_df["year"] = years_df["analysis_month"].str[:4].astype(int)
+                all_drainage_years = years_df.groupby("id_geohash")["year"].max().to_dict()
+
         tooltip = None
         m = build_pmtiles_map(
             pmtiles_url,
@@ -342,6 +351,7 @@ class MapViewer:
             drained_ids=drained_ids,
             viz_configuration_name=viz_configuration_name,
             tooltip=tooltip,
+            all_drainage_years=all_drainage_years,
         )
 
         # Render the map and get click data

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -973,7 +973,6 @@ def create_app(
     dw_end_year: int = 2025,
     dw_start_month: int = 6,
     dw_end_month: int = 9,
-    viz_configuration_name: Optional[str] = "colored_historical",
     pmtiles_file: Optional[str | Path] = None,
     pmtiles_url: Optional[str] = None,
     logfile: Optional[str] = None,
@@ -995,7 +994,6 @@ def create_app(
         dw_end_year: End year for Dynamic World time series (inclusive).
         dw_start_month: Start month for Dynamic World time series (1-12).
         dw_end_month: End month for Dynamic World time series (1-12).
-        viz_configuration_name: Map styling preset.
         pmtiles_file: Path to a ``.pmtiles`` archive (enables fast vector-tile map).
         pmtiles_url: HTTP(S) URL to a hosted ``.pmtiles`` file (e.g. on S3).
     """
@@ -1034,6 +1032,21 @@ def create_app(
         st.sidebar.caption("🖱️ Interactive mode - hover to see values, zoom & pan available")
     else:
         st.sidebar.caption("📊 Static mode - matplotlib plots")
+
+    st.sidebar.divider()
+    st.sidebar.subheader("Map Styling")
+    viz_style_options = {
+        "Net Change %": "colored_historical",
+        "Year Drainage": "drainage_year"
+    }
+    
+    selected_viz_label = st.sidebar.selectbox(
+        "Visualization Style",
+        options=list(viz_style_options.keys()),
+        index=0,
+        help="Select the visualization style for the map"
+    )
+    viz_configuration_name = viz_style_options[selected_viz_label]
 
     use_pmtiles = bool(pmtiles_file or pmtiles_url)
     map_backend = "pmtiles" if use_pmtiles else "folium"

--- a/src/water_timeseries/dashboard/static/lake_map.html
+++ b/src/water_timeseries/dashboard/static/lake_map.html
@@ -122,28 +122,37 @@
     const viz = CONFIG.viz_configuration || "colored_historical";
     const sourceLayer = CONFIG.source_layer || "lakes";
 
-    //  1. If NetChange_perc is a number  → historical colour ramp (red→blue)
-    //  2. Else if date_break_year is present → drainage_year colour ramp
-    //  3. Otherwise                           → neutral grey
-    const dataDrivenFillColor = [
-      "case",
-      ["==", ["typeof", ["get", "NetChange_perc"]], "number"],
-      [
-        "interpolate", ["linear"], ["get", "NetChange_perc"],
-        -40, "#d73027",
-        -20, "#f46d43",
-          0, "#fee090",
-         20, "#74add1",
-         40, "#4575b4"
-      ],
-      ["has", "date_break_year"],
-      [
-        "interpolate", ["linear"], ["to-number", ["get", "date_break_year"]],
-        2017.0, "#fff5f0",
-        2025.0, "#67000d"
-      ],
-      "#888888"
+    const netChangeRamp = [
+      "interpolate", ["linear"], ["get", "NetChange_perc"],
+      -40, "#d73027",
+      -20, "#f46d43",
+        0, "#fee090",
+       20, "#74add1",
+       40, "#4575b4"
     ];
+
+    const drainageYearRamp = [
+      "interpolate", ["linear"], ["to-number", ["get", "date_break_year"]],
+      2017.0, "#fff5f0",
+      2026.0, "#67000d"
+    ];
+
+    let dataDrivenFillColor;
+    if (viz === "drainage_year") {
+      dataDrivenFillColor = [
+        "case",
+        ["has", "date_break_year"], drainageYearRamp,
+        ["==", ["typeof", ["get", "NetChange_perc"]], "number"], netChangeRamp,
+        "#888888"
+      ];
+    } else {
+      dataDrivenFillColor = [
+        "case",
+        ["==", ["typeof", ["get", "NetChange_perc"]], "number"], netChangeRamp,
+        ["has", "date_break_year"], drainageYearRamp,
+        "#888888"
+      ];
+    }
 
     let lakePaint = {
       "fill-color": dataDrivenFillColor,
@@ -484,7 +493,7 @@
       if (hasNetChange) {
         legend.innerHTML = "<b>Net change (%)</b><div class='legend-bar'></div><div style='display:flex;justify-content:space-between'><span>-40%</span><span>0</span><span>+40%</span></div>";
       } else if (hasDrainageYear) {
-        legend.innerHTML = "<b>Drainage year</b><div class='legend-bar' style='background:linear-gradient(to right,#fff5f0,#67000d)'></div><div style='display:flex;justify-content:space-between'><span>2017</span><span>2025</span></div>";
+        legend.innerHTML = "<b>Drainage year</b><div class='legend-bar' style='background:linear-gradient(to right,#fff5f0,#67000d)'></div><div style='display:flex;justify-content:space-between'><span>2017</span><span>2026</span></div>";
       }
     }
 

--- a/src/water_timeseries/map_utils.py
+++ b/src/water_timeseries/map_utils.py
@@ -107,6 +107,7 @@ def build_pmtiles_map(
     drained_ids: list[str] | None = None,
     viz_configuration_name: str = "colored_historical",
     tooltip=None,
+    all_drainage_years: dict[str, int] | None = None,
 ) -> folium.Map:
     """Return a Folium map with a PMTiles vector layer for lake polygons."""
     m = leafmap.Map(
@@ -143,7 +144,7 @@ def build_pmtiles_map(
 
     elif viz_configuration_name == "drainage_year":
         # Convert to number to handle string values in PMTiles
-        fill_color, fill_opacity, line_color, line_width, line_opacity = get_style_pmtiles_drainage_year()
+        fill_color, fill_opacity, line_color, line_width, line_opacity = get_style_pmtiles_drainage_year(all_drainage_years)
         legend = get_legend_html_date_drainage_year()
 
         # Use only one basemap to avoid overlap

--- a/src/water_timeseries/scripts/cli.py
+++ b/src/water_timeseries/scripts/cli.py
@@ -91,7 +91,6 @@ def dashboard(
     dw_end_year: Optional[int] = None,
     dw_start_month: Optional[int] = None,
     dw_end_month: Optional[int] = None,
-    viz_configuration: Optional[str] = None,
     pmtiles_file: Optional[str] = None,
     pmtiles_url: Optional[str] = None,
     port: Optional[int] = None,
@@ -156,7 +155,6 @@ def dashboard(
         dw_end_year=dw_end_year,
         dw_start_month=dw_start_month,
         dw_end_month=dw_end_month,
-        viz_configuration=viz_configuration,
         pmtiles_file=pmtiles_file,
         pmtiles_url=pmtiles_url,
         port=port,
@@ -176,7 +174,6 @@ def dashboard(
     dw_end_year = config_dict.get("dw_end_year", 2025)
     dw_start_month = config_dict.get("dw_start_month", 6)
     dw_end_month = config_dict.get("dw_end_month", 9)
-    viz_configuration = config_dict.get("viz_configuration", "colored_historical")
     pmtiles_file = config_dict.get("pmtiles_file")
     pmtiles_url = config_dict.get("pmtiles_url")
     port = config_dict.get("port", 8501)
@@ -220,8 +217,6 @@ def dashboard(
         script_args.extend(["--dw-start-month", str(dw_start_month)])
     if dw_end_month is not None:
         script_args.extend(["--dw-end-month", str(dw_end_month)])
-    if viz_configuration:
-        script_args.extend(["--viz-configuration", viz_configuration])
     if pmtiles_file:
         script_args.extend(["--pmtiles-file", pmtiles_file])
     if pmtiles_url:
@@ -236,7 +231,7 @@ def dashboard(
         f"Dashboard config: port={port}, vector_file={vector_file}, "
         f"dw_dataset_file={dw_dataset_file}, jrc_dataset_file={jrc_dataset_file}, "
         f"precomputed_nrt_dir={precomputed_nrt_dir}, offline_mode={offline_mode}, "
-        f"ee_project={ee_project}, viz_configuration={viz_configuration}, "
+        f"ee_project={ee_project}, "
         f"dw_start_year={dw_start_year}, dw_end_year={dw_end_year}, "
         f"dw_start_month={dw_start_month}, dw_end_month={dw_end_month}, "
         f"logfile={logfile}"

--- a/src/water_timeseries/utils/map_styles/pmtiles.py
+++ b/src/water_timeseries/utils/map_styles/pmtiles.py
@@ -16,7 +16,7 @@ def get_style_pmtiles_colored_historical() -> tuple:
         "#4575b4",
     ]
     fill_opacity = 0.7
-    line_color = "#333333"
+    line_color = fill_color
     line_width = 0.5
     line_opacity = 1
     return fill_color, fill_opacity, line_color, line_width, line_opacity
@@ -42,18 +42,7 @@ def get_style_pmtiles_drainage_year(all_drainage_years: dict[str, int] | None = 
         "#67000d",
     ]
     fill_opacity = 0.4
-    line_color = [
-        "interpolate",
-        ["linear"],
-        value_expr,
-        2017,
-        "#fff5f0",
-        2021,
-        "#f46d43",
-        2026,
-        "#67000d",
-    ]
-    # line_color = "#dddddd"
-    line_width = 3
+    line_color = fill_color
+    line_width = 0.5
     line_opacity = 1
     return fill_color, fill_opacity, line_color, line_width, line_opacity

--- a/src/water_timeseries/utils/map_styles/pmtiles.py
+++ b/src/water_timeseries/utils/map_styles/pmtiles.py
@@ -22,26 +22,35 @@ def get_style_pmtiles_colored_historical() -> tuple:
     return fill_color, fill_opacity, line_color, line_width, line_opacity
 
 
-def get_style_pmtiles_drainage_year() -> tuple:
+def get_style_pmtiles_drainage_year(all_drainage_years: dict[str, int] | None = None) -> tuple:
+    if all_drainage_years:
+        match_expr = ["match", ["get", "id_geohash"]]
+        for geohash, year in all_drainage_years.items():
+            match_expr.extend([geohash, year])
+        match_expr.append(["to-number", ["get", "date_break_year"]])
+        value_expr = match_expr
+    else:
+        value_expr = ["to-number", ["get", "date_break_year"]]
+
     fill_color = [
         "interpolate",
         ["linear"],
-        ["to-number", ["get", "date_break_year"]],
+        value_expr,
         2017.0,
         "#fff5f0",
-        2025.0,
+        2026.0,
         "#67000d",
     ]
     fill_opacity = 0.4
     line_color = [
         "interpolate",
         ["linear"],
-        ["to-number", ["get", "date_break_year"]],
+        value_expr,
         2017,
         "#fff5f0",
         2021,
         "#f46d43",
-        2025,
+        2026,
         "#67000d",
     ]
     # line_color = "#dddddd"


### PR DESCRIPTION
This PR introduces improvements to how map visualization styles are selected and rendered on the dashboard, specifically fixing the missing styling for recent lake drainages.

**Key Changes:**
* **Dynamic Drainage Year Rendering:** Updated the map styling logic to dynamically merge Near Real-Time (NRT) `date_break_year` data into the MapLibre PMTiles. This ensures recently drained lakes (e.g., those from 2023 onwards) correctly appear with their respective year colors in the "Year Drainage" view instead of falling back to the default grey/transparent style.
* **UI Improvements:** Added a new interactive dropdown menu in the dashboard sidebar to easily toggle between visualization styles (e.g., Historical colored vs. Year Drainage). Lines for polygons are the same thickness between style and are the same color as the fill for uniformity.
* **CLI Cleanup:** Removed the legacy CLI flag for color-coding styles, as this is now handled dynamically via the dashboard UI.
<img width="800" height="879" alt="ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/fe8a1166-8fa0-4f0d-ad82-73175c78f67d" />

