### PR TITLE
Shareable links: URL restores exact window state, with parent-site iframe support

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -127,6 +127,9 @@ All messages are objects with `type` and `version: 1`.
    python -m http.server 8000
    ```
 
-4. Pan, zoom, select a lake, flip toggles — the parent address bar gains
-   `wt_*` params live. Click **🔗 Copy link to this view** and paste into a
-   fresh tab: the parent page loads with the iframe restored to the same state.
+4. Pan, zoom, select a lake, flip toggles — the *parent page's* address bar
+   gains `wt_*` params live. Copy it (e.g. `Cmd/Ctrl+L`, `Cmd/Ctrl+C`) and paste
+   into a fresh tab: the parent page loads with the iframe restored to the
+   same state. The dashboard's own **🔗 Copy link to this view** button
+   copies the dashboard's own direct URL instead — useful standalone, or to
+   link straight to the framed app outside the parent page.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,127 @@
+# Embedding & shareable links
+
+The dashboard keeps its window state in readable URL query params, so any URL
+copied from the address bar (or via the sidebar **🔗 Copy link to this view**
+button) restores the exact same view when pasted.
+
+## State params
+
+| Param | Format | Meaning |
+|---|---|---|
+| `selected_lake` | 12-char geohash | Currently selected lake |
+| `lat`, `lon` | float (5 decimals) | Map center |
+| `zoom` | float (2 decimals) | Map zoom level |
+| `drained` | `1` | "Show temporal drainage statistics" toggle is on |
+| `month` | `YYYY-MM` | Selected historical-drainage analysis month |
+| `hide_stable` | `1` | "Hide stable lakes" toggle is on |
+
+Params at their default value are omitted. Example:
+
+```
+https://dashboard.example.org/?selected_lake=b7zpm2xq4k9d&lat=66.512&lon=-164.087&zoom=12&drained=1&month=2024-06
+```
+
+The visualization preset (`--viz-configuration`) is fixed per deployment and is
+not part of the URL.
+
+## Embedding in a parent site
+
+When the dashboard is embedded in an iframe, links must point at the *parent*
+page, not the framed app. The parent page cooperates via
+[`embed/water-timeseries-embed.js`](https://github.com/PermafrostDiscoveryGateway/water-timeseries-v2/tree/main/embed):
+
+```html
+<iframe id="wt-frame" allow="clipboard-write" title="Water Timeseries dashboard"></iframe>
+
+<script src="water-timeseries-embed.js"></script>
+<script>
+  WaterTimeseriesEmbed.init({
+    iframe: "#wt-frame",
+    appUrl: "https://your-dashboard.example.org",
+  });
+</script>
+```
+
+The snippet:
+
+1. **On load**, copies `wt_`-prefixed params from the parent URL into the
+   iframe `src` (unprefixed), plus `embed=true` — so a pasted parent link
+   restores the embedded dashboard state.
+2. **Answers the handshake** (`wt:hello` → `wt:hello-ack`) so the dashboard's
+   copy button knows a cooperating parent exists and builds parent-site URLs
+   (state params carried with the `wt_` prefix to avoid collisions with the
+   parent page's own params).
+3. **Mirrors live state** (`wt:state` messages) onto the parent URL via
+   `history.replaceState`, so the parent address bar stays shareable as the
+   user pans, zooms, selects lakes, and flips toggles.
+
+Requirements:
+
+- `allow="clipboard-write"` on the iframe tag — without it, the copy button
+  cannot write to the clipboard directly and falls back to a selectable text
+  field.
+- The snippet only accepts messages whose origin matches `appUrl`.
+
+### Locking down the message target
+
+By default the dashboard posts state messages with target origin `*` (they
+contain only the state params above — nothing sensitive). To restrict them to
+a single parent origin, set an environment variable on the dashboard host:
+
+```bash
+WT_PARENT_ORIGIN=https://parent-site.example.org
+```
+
+With this set, messages are only delivered to that origin and acks from other
+origins are ignored; framed by anyone else, the copy button falls back to
+producing the app's own direct URL.
+
+## postMessage protocol reference
+
+All messages are objects with `type` and `version: 1`.
+
+| Type | Direction | Payload |
+|---|---|---|
+| `wt:hello` | dashboard → parent (`window.top`) | `{}` — sent when the copy button mounts |
+| `wt:hello-ack` | parent → dashboard | `{ href, prefix }` — parent page URL and param prefix |
+| `wt:state` | dashboard → parent (`window.top`) | `{ params }` — current state params; absent keys mean "remove" |
+
+## Local end-to-end test
+
+1. Start the dashboard as usual (it listens on `http://localhost:8501`):
+
+   ```bash
+   water-timeseries dashboard --pmtiles-file <tiles.pmtiles> \
+       --viz-configuration nrt_drainage --precomputed-nrt-dir <dir>
+   ```
+
+2. Create a minimal parent page next to `water-timeseries-embed.js`
+   (e.g. `embed/parent.html` — kept out of version control):
+
+   ```html
+   <!DOCTYPE html>
+   <html>
+   <body>
+     <iframe id="wt-frame" allow="clipboard-write"
+             style="width: 100%; height: 90vh; border: 1px solid #ccc;"></iframe>
+     <script src="water-timeseries-embed.js"></script>
+     <script>
+       WaterTimeseriesEmbed.init({
+         iframe: "#wt-frame",
+         appUrl: "http://localhost:8501",
+       });
+     </script>
+   </body>
+   </html>
+   ```
+
+3. Serve the repo over a *different* origin (realistic cross-origin setup)
+   and open <http://localhost:8000/embed/parent.html>:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+4. Pan, zoom, select a lake, flip toggles — the parent address bar gains
+   `wt_*` params live. Click **🔗 Copy link to this view** and paste into a
+   fresh tab: the parent page loads with the iframe restored to the same state.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -24,6 +24,17 @@ https://dashboard.example.org/?selected_lake=b7zpm2xq4k9d&lat=66.512&lon=-164.08
 The visualization preset (`--viz-configuration`) is fixed per deployment and is
 not part of the URL.
 
+## Embed config params
+
+These configure how the app behaves when embedded; they're read once on load
+and are never part of the shareable state above (an embedding parent sets
+them, they're not echoed back via postMessage or included in copied links).
+
+| Param | Format | Meaning |
+|---|---|---|
+| `theme` | `light` \| `dark` | Forces the color scheme, overriding the browser's `prefers-color-scheme` |
+| `show_share` | `false` | Hides the sidebar **🔗 Copy link to this view** button (e.g. when the embedding parent offers its own shareable link) |
+
 ## Embedding in a parent site
 
 When the dashboard is embedded in an iframe, links must point at the *parent*

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -89,7 +89,17 @@ All messages are objects with `type` and `version: 1`.
 
 | Type | Direction | Payload |
 |---|---|---|
-| `mcui:state` | dashboard → parent (`window.top`) | `{ params }` — current state params; absent keys mean "remove" |
+| `mcui:state` | dashboard → parent (`window.top`) | `{ url }` — this app's own current URL (shareable state params only, no embed config); the parent extracts state from it directly |
+
+The dashboard posts its own URL rather than a bespoke params object so a parent
+doesn't need to hardcode this app's param names. A parent with a richer
+integration (e.g. one that already owns an RFC 6570 URI template for its
+iframe config, such as MetacatUI) can run that template's de-substitution
+against the incoming URL to extract and whitelist state instead of trusting
+it outright. The reference snippet here does the simpler equivalent: it
+copies the incoming URL's query params onto the parent URL under the `wt_`
+prefix, relying on the `event.origin` check above rather than a template
+whitelist.
 
 ## Local end-to-end test
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -47,13 +47,10 @@ The snippet:
 1. **On load**, copies `wt_`-prefixed params from the parent URL into the
    iframe `src` (unprefixed), plus `embed=true` — so a pasted parent link
    restores the embedded dashboard state.
-2. **Answers the handshake** (`wt:hello` → `wt:hello-ack`) so the dashboard's
-   copy button knows a cooperating parent exists and builds parent-site URLs
-   (state params carried with the `wt_` prefix to avoid collisions with the
-   parent page's own params).
-3. **Mirrors live state** (`wt:state` messages) onto the parent URL via
-   `history.replaceState`, so the parent address bar stays shareable as the
-   user pans, zooms, selects lakes, and flips toggles.
+2. **Mirrors live state** (`mcui:state` messages) onto the parent URL via
+   `history.replaceState` (state params carried with the `wt_` prefix to avoid
+   collisions with the parent page's own params), so the parent address bar
+   stays shareable as the user pans, zooms, selects lakes, and flips toggles.
 
 Requirements:
 
@@ -72,9 +69,8 @@ a single parent origin, set an environment variable on the dashboard host:
 WT_PARENT_ORIGIN=https://parent-site.example.org
 ```
 
-With this set, messages are only delivered to that origin and acks from other
-origins are ignored; framed by anyone else, the copy button falls back to
-producing the app's own direct URL.
+With this set, messages are only delivered to that origin; framed by anyone
+else, the message is silently dropped by the browser instead of leaking state.
 
 ## postMessage protocol reference
 
@@ -82,9 +78,7 @@ All messages are objects with `type` and `version: 1`.
 
 | Type | Direction | Payload |
 |---|---|---|
-| `wt:hello` | dashboard → parent (`window.top`) | `{}` — sent when the copy button mounts |
-| `wt:hello-ack` | parent → dashboard | `{ href, prefix }` — parent page URL and param prefix |
-| `wt:state` | dashboard → parent (`window.top`) | `{ params }` — current state params; absent keys mean "remove" |
+| `mcui:state` | dashboard → parent (`window.top`) | `{ params }` — current state params; absent keys mean "remove" |
 
 ## Local end-to-end test
 

--- a/embed/README.md
+++ b/embed/README.md
@@ -1,0 +1,10 @@
+# Parent-site embed helper
+
+`water-timeseries-embed.js` is a drop-in snippet for a parent page embedding
+the Water Timeseries dashboard with shareable deep links. It forwards `wt_*`
+params from the parent URL into the iframe on load, and mirrors the
+dashboard's live state back onto the parent URL so links (address bar or the
+dashboard's "Copy link" button) restore the exact embedded state.
+
+Full documentation, including a local test setup with a sample parent page:
+[docs/embedding.md](../docs/embedding.md).

--- a/embed/water-timeseries-embed.js
+++ b/embed/water-timeseries-embed.js
@@ -1,0 +1,87 @@
+/**
+ * Water Timeseries embed helper for parent sites.
+ *
+ * Enables shareable deep links when the dashboard is embedded in an iframe:
+ *  - On load, forwards wt_-prefixed state params from the parent page URL into
+ *    the iframe src (so a pasted link restores the embedded dashboard state).
+ *  - Listens for state updates from the dashboard and mirrors them onto the
+ *    parent page URL via history.replaceState (so the address bar and the
+ *    dashboard's "Copy link" button always reflect the current state).
+ *
+ * Usage:
+ *   <iframe id="wt-frame" allow="clipboard-write"></iframe>
+ *   <script src="water-timeseries-embed.js"></script>
+ *   <script>
+ *     WaterTimeseriesEmbed.init({
+ *       iframe: "#wt-frame",
+ *       appUrl: "https://your-dashboard.example.org",
+ *     });
+ *   </script>
+ *
+ * The iframe MUST carry allow="clipboard-write" for the dashboard's copy
+ * button to reach the clipboard directly (it falls back to a selectable text
+ * field otherwise).
+ */
+(function (global) {
+  "use strict";
+
+  var DEFAULT_PREFIX = "wt_";
+
+  function init(options) {
+    if (!options || !options.appUrl) {
+      throw new Error("WaterTimeseriesEmbed.init: appUrl is required");
+    }
+    var iframe =
+      typeof options.iframe === "string"
+        ? document.querySelector(options.iframe)
+        : options.iframe;
+    if (!iframe) {
+      throw new Error("WaterTimeseriesEmbed.init: iframe not found");
+    }
+    var prefix = options.prefix || DEFAULT_PREFIX;
+    var appOrigin = new URL(options.appUrl, global.location.href).origin;
+
+    // 1) Forward wt_* params from the parent URL into the iframe src.
+    var appUrl = new URL(options.appUrl, global.location.href);
+    var pageParams = new URLSearchParams(global.location.search);
+    pageParams.forEach(function (value, key) {
+      if (key.indexOf(prefix) === 0) {
+        appUrl.searchParams.set(key.slice(prefix.length), value);
+      }
+    });
+    if (!appUrl.searchParams.has("embed")) {
+      appUrl.searchParams.set("embed", "true");
+    }
+    iframe.src = appUrl.toString();
+
+    // 2) Answer the dashboard's handshake and mirror its state onto our URL.
+    global.addEventListener("message", function (event) {
+      if (event.origin !== appOrigin) return;
+      var data = event.data;
+      if (!data || typeof data !== "object") return;
+
+      if (data.type === "wt:hello") {
+        event.source.postMessage(
+          { type: "wt:hello-ack", version: 1, href: global.location.href, prefix: prefix },
+          event.origin
+        );
+      } else if (data.type === "wt:state") {
+        var url = new URL(global.location.href);
+        var stale = [];
+        url.searchParams.forEach(function (value, key) {
+          if (key.indexOf(prefix) === 0) stale.push(key);
+        });
+        stale.forEach(function (key) {
+          url.searchParams.delete(key);
+        });
+        var params = data.params || {};
+        Object.keys(params).forEach(function (key) {
+          url.searchParams.set(prefix + key, params[key]);
+        });
+        global.history.replaceState(null, "", url.toString());
+      }
+    });
+  }
+
+  global.WaterTimeseriesEmbed = { init: init };
+})(window);

--- a/embed/water-timeseries-embed.js
+++ b/embed/water-timeseries-embed.js
@@ -54,18 +54,13 @@
     }
     iframe.src = appUrl.toString();
 
-    // 2) Answer the dashboard's handshake and mirror its state onto our URL.
+    // 2) Mirror the dashboard's state onto our URL.
     global.addEventListener("message", function (event) {
       if (event.origin !== appOrigin) return;
       var data = event.data;
       if (!data || typeof data !== "object") return;
 
-      if (data.type === "wt:hello") {
-        event.source.postMessage(
-          { type: "wt:hello-ack", version: 1, href: global.location.href, prefix: prefix },
-          event.origin
-        );
-      } else if (data.type === "wt:state") {
+      if (data.type === "mcui:state") {
         var url = new URL(global.location.href);
         var stale = [];
         url.searchParams.forEach(function (value, key) {

--- a/embed/water-timeseries-embed.js
+++ b/embed/water-timeseries-embed.js
@@ -61,6 +61,13 @@
       if (!data || typeof data !== "object") return;
 
       if (data.type === "mcui:state") {
+        if (typeof data.url !== "string") return;
+        var incoming;
+        try {
+          incoming = new URL(data.url);
+        } catch (e) {
+          return;
+        }
         var url = new URL(global.location.href);
         var stale = [];
         url.searchParams.forEach(function (value, key) {
@@ -69,9 +76,8 @@
         stale.forEach(function (key) {
           url.searchParams.delete(key);
         });
-        var params = data.params || {};
-        Object.keys(params).forEach(function (key) {
-          url.searchParams.set(prefix + key, params[key]);
+        incoming.searchParams.forEach(function (value, key) {
+          url.searchParams.set(prefix + key, value);
         });
         global.history.replaceState(null, "", url.toString());
       }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - Home: index.md
   - Getting Started: getting_started.md
   - Examples: examples.md
+  - Embedding & Shareable Links: embedding.md
   - API Reference:
     - Overview: api/index.md
     - Dataset: api/dataset.md

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -17,10 +17,12 @@ from streamlit_folium import st_folium
 
 from water_timeseries.dashboard.share_state import (
     adopt_live_view,
+    apply_theme_param,
     apply_url_state_once,
     render_copy_link_button,
     render_state_bridge,
     set_desired_view,
+    share_button_enabled,
     sync_flag_param,
     update_live_view,
 )
@@ -1142,6 +1144,9 @@ def create_app(
     if st.session_state.disable_popup_plot:
         logger.warning("Plot popup disabled!")
 
+    # Force the embed color scheme before any other content renders, if requested.
+    apply_theme_param()
+
     # Restore shared window state from URL (once per session), then adopt the
     # user's live panned/zoomed view so the map is rebuilt where they left it.
     apply_url_state_once()
@@ -1185,8 +1190,10 @@ def create_app(
         show_help_button(config_name=viz_configuration_name)
 
     # Copy-link button: copies a URL that restores the exact window state
-    with st.sidebar:
-        render_copy_link_button()
+    # (hidden via show_share=false, e.g. when an embedding parent has its own).
+    if share_button_enabled():
+        with st.sidebar:
+            render_copy_link_button()
 
     # Show offline mode indicator
     if offline_mode:

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -15,6 +15,15 @@ import streamlit as st
 from loguru import logger
 from streamlit_folium import st_folium
 
+from water_timeseries.dashboard.share_state import (
+    adopt_live_view,
+    apply_url_state_once,
+    render_copy_link_button,
+    render_state_bridge,
+    set_desired_view,
+    sync_flag_param,
+    update_live_view,
+)
 from water_timeseries.dashboard.tutorial_popup import show_help_button, show_tutorial_popup
 from water_timeseries.dataset import DWDataset, JRCDataset
 from water_timeseries.downloader import EarthEngineDownloader
@@ -371,8 +380,13 @@ class MapViewer:
                 "last_object_clicked",
                 "last_object_clicked_tooltip",
                 "last_clicked",
+                "center",
+                "zoom",
             ],
         )
+
+        # Track the user's live view (feeds the shareable URL, not map construction)
+        update_live_view(map_data.get("center"), map_data.get("zoom"))
 
         # Extract clicked feature's id_geohash for time-series lookup
         clicked_id = None
@@ -409,8 +423,8 @@ class MapViewer:
                     if clicked_id:
                         logger.info(f"Found lake via spatial search: {clicked_id}")
                         clicked_lat, clicked_lon = pygeohash.decode(clicked_id)
-                        st.session_state.map_center = {"lat": clicked_lat, "lon": clicked_lon}
-                        st.session_state.zoom_level = 12
+                        set_desired_view(clicked_lat, clicked_lon, 12)
+                        st.session_state["_centered_selection"] = clicked_id
                         logger.info(f"Clicked on lake {clicked_id} and coordinate {clicked_lat} {clicked_lon}")
 
         # Update session state only if a NEW feature was clicked
@@ -420,9 +434,8 @@ class MapViewer:
             logger.info(f"New lake selected: {clicked_id}")
 
             clicked_lat, clicked_lon = pygeohash.decode(clicked_id)
-            # self.map_center = {'lat': clicked_lat, 'lon': clicked_lon}
-            st.session_state.map_center = {"lat": clicked_lat, "lon": clicked_lon}
-            st.session_state.zoom_level = 12
+            set_desired_view(clicked_lat, clicked_lon, 12)
+            st.session_state["_centered_selection"] = clicked_id
             logger.info(f"Clicked on lake {clicked_id} and coodinate {clicked_lat} {clicked_lon}")
             if clicked_id not in st.session_state.get("clicked_features", []):
                 if "clicked_features" not in st.session_state:
@@ -610,8 +623,15 @@ class MapViewer:
 
         # Render the map and get click data
         # Note: returned_objects includes 'last_active_drawing' for click detection
-        result = st_folium(m, height=600, width="100%", key="map_viewer", returned_objects=["last_active_drawing"])
-        # st.session_state.zoom_level = 6
+        result = st_folium(
+            m,
+            height=600,
+            width="100%",
+            key="map_viewer",
+            returned_objects=["last_active_drawing", "center", "zoom"],
+        )
+        # Track the user's live view (feeds the shareable URL, not map construction)
+        update_live_view(result.get("center"), result.get("zoom"))
 
         # Extract id_geohash from clicked feature
         clicked_id = None
@@ -659,6 +679,7 @@ class MapViewer:
         st.session_state.pop("selected_geohash", None)
         st.session_state.pop("selected_geohash_readable", None)
         st.session_state.pop("_pmtiles_last_rerun", None)
+        st.session_state.pop("_centered_selection", None)
 
     def _fix_current_view(self) -> None:
         """Fix the current map view (center and zoom) in session state.
@@ -909,6 +930,9 @@ def _render_drain_heatmap(
                         st.session_state.selected_geohash = drained_id
                         st.session_state.clicked_features.append(drained_id)
                         st.query_params["selected_lake"] = drained_id
+                        drained_lat, drained_lon = pygeohash.decode(drained_id)
+                        set_desired_view(drained_lat, drained_lon, 12)
+                        st.session_state["_centered_selection"] = drained_id
 
         # dummy deactivate clear selection button
         if False:
@@ -1099,11 +1123,12 @@ def create_app(
         logger.info(
             f"Setting center map to match lake id: {selected_option} at location ({clicked_lat}, {clicked_lon})"
         )
-        st.session_state.map_center = {"lat": clicked_lat, "lon": clicked_lon}
-        st.session_state.zoom_level = 12
+        set_desired_view(clicked_lat, clicked_lon, 12)
+        st.session_state["_centered_selection"] = selected_option
 
     def _clear_selection():
         st.session_state.pop("selected_geohash", None)
+        st.session_state.pop("_centered_selection", None)
         st.query_params.pop("selected_lake", None)
         st.rerun()
 
@@ -1117,8 +1142,17 @@ def create_app(
     if st.session_state.disable_popup_plot:
         logger.warning("Plot popup disabled!")
 
+    # Restore shared window state from URL (once per session), then adopt the
+    # user's live panned/zoomed view so the map is rebuilt where they left it.
+    apply_url_state_once()
+    adopt_live_view()
+
     # check if there is a selected lake and jump to it if available
-    if st.session_state.get("selected_geohash", None):
+    # (only once per selection, so it doesn't fight a restored or panned view)
+    if (
+        st.session_state.get("selected_geohash", None)
+        and st.session_state.get("_centered_selection") != st.session_state.selected_geohash
+    ):
         _set_center_to_selected()
 
     # Store offline_mode in session state so it's accessible throughout the app
@@ -1149,6 +1183,10 @@ def create_app(
     # st.sidebar.header("Settings")
     with st.sidebar.divider():
         show_help_button(config_name=viz_configuration_name)
+
+    # Copy-link button: copies a URL that restores the exact window state
+    with st.sidebar:
+        render_copy_link_button()
 
     # Show offline mode indicator
     if offline_mode:
@@ -1221,11 +1259,19 @@ def create_app(
     # Near-real-time drainage overlay
     st.sidebar.divider()
     st.sidebar.subheader("Historical Drainage")
+    st.session_state.setdefault("show_drained_toggle", default_activate_historical)
     show_drained = st.sidebar.toggle(
         "Show temporal drainage statistics",
-        value=default_activate_historical,
+        key="show_drained_toggle",
         help="Activates visualization of number of drained lakes per month.",
     )
+    sync_flag_param("drained", show_drained)
+    if not show_drained:
+        st.query_params.pop("month", None)
+    # Jump to the drainage overview zoom only when the toggle flips on,
+    # not on every rerun (would fight a restored or user-panned view).
+    drained_just_enabled = show_drained and not st.session_state.get("_prev_show_drained", False)
+    st.session_state["_prev_show_drained"] = show_drained
     drained_breaks = None
     drained_label = None
 
@@ -1285,6 +1331,15 @@ def create_app(
 
                 selected_analysis_month = heatmap_pick
 
+                # Keep the shareable month param in sync with the selected month
+                if selected_analysis_month:
+                    if st.query_params.get("month") != selected_analysis_month:
+                        st.query_params["month"] = selected_analysis_month
+                    if selected_analysis_month not in selectable_months:
+                        st.sidebar.caption(
+                            f"Month {selected_analysis_month} from the shared link is not available."
+                        )
+
                 if precomputed_breaks is not None and "analysis_month" in precomputed_breaks.columns:
                     month_slice = precomputed_breaks.query("analysis_month == @selected_analysis_month")
                     if not month_slice.empty:
@@ -1316,16 +1371,17 @@ def create_app(
 
             try:
                 # st.write(f"DEBUG: fragment running, hide_stable_lakes={st.session_state.get('toggle_hide_stable_lakes')}")
-                if show_drained and drained_breaks is not None and st.session_state.selected_geohash is None:
+                if drained_just_enabled and drained_breaks is not None and st.session_state.selected_geohash is None:
                     logger.info("Setting zoom level to 6")
-                    st.session_state.zoom_level = 6
+                    overview_center = st.session_state.map_center
+                    set_desired_view(overview_center["lat"], overview_center["lon"], 6)
 
                 if viz_configuration_name in ["drainage_year", "nrt_drainage"]:
                     hide_stable_lakes = st.toggle(
                         "Hide stable lakes",
-                        value=st.session_state.get("hide_stable_lakes", False),
                         key="toggle_hide_stable_lakes",
                     )
+                    sync_flag_param("hide_stable", hide_stable_lakes)
                 else:
                     hide_stable_lakes = False
 
@@ -1370,6 +1426,10 @@ def create_app(
                 # Render the map INSIDE the fragment
                 selected = viewer.render()
 
+                # Mirror the current state params to a cooperating parent page
+                # (re-posts on fragment reruns, e.g. after pan/zoom)
+                render_state_bridge()
+
                 return viewer, selected
             except Exception as e:  # noqa: BLE001
                 st.error(f"Error loading data: {e!s}")
@@ -1410,8 +1470,8 @@ def create_app(
                 st.query_params["selected_lake"] = selected_option
                 # change map params
                 clicked_lat, clicked_lon = pygeohash.decode(selected_option)
-                st.session_state.map_center = {"lat": clicked_lat, "lon": clicked_lon}
-                st.session_state.zoom_level = 12
+                set_desired_view(clicked_lat, clicked_lon, 12)
+                st.session_state["_centered_selection"] = selected_option
                 st.rerun()
         else:
             st.sidebar.info("No features clicked yet. Click on a feature to select it.")

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -493,12 +493,13 @@ class MapViewer:
         tile_layer_darkmatter = folium.TileLayer("CartoDB.DarkMatter", name="Dark Matter (CartoDB)")
         tile_layer_esriworld = folium.TileLayer("Esri.WorldImagery", name="ESRI World Imagery")
 
+        tooltip_columns = None
+
         if viz_configuration_name == "colored_historical":
             # Create style function based on whether NetChange_perc column exists
             if "NetChange_perc" in valid_gdf.columns:
                 # add tile layers
-                m.add_basemap("CartoDB.DarkMatter", name="Dark Matter (CartoDB)")
-                # tile_layer_darkmatter.add_to(m)
+                tile_layer_darkmatter.add_to(m)
                 tile_layer_esriworld.add_to(m)
                 tcvis_tile_layer.add_to(m)
 

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -1451,36 +1451,39 @@ def create_app(
 
         clicked = viewer.get_clicked_features()
 
+        def _on_clicked_lake_dropdown_change():
+            selected_option = st.session_state.get("clicked_lakes_dropdown")
+            if selected_option and selected_option != st.session_state.get("selected_geohash"):
+                st.session_state.selected_geohash = selected_option
+                st.query_params["selected_lake"] = selected_option
+                clicked_lat, clicked_lon = pygeohash.decode(selected_option)
+                set_desired_view(clicked_lat, clicked_lon, 12)
+                st.session_state["_centered_selection"] = selected_option
+
         # Create a dropdown for selecting from previously clicked features
         if clicked:
             # Reverse to show latest clicked at the top
             options = list(reversed(clicked))
             current = viewer.get_selected_geohash()
 
-            # Set default index based on current selection
-            if current and current in options:
-                default_idx = options.index(current)
-            else:
-                default_idx = 0
+            # Keep the dropdown's own widget state in sync with selections made
+            # elsewhere (map click, clear button) since a keyed widget otherwise
+            # ignores `index` after its first render.
+            if current and current in options and st.session_state.get("clicked_lakes_dropdown") != current:
+                st.session_state["clicked_lakes_dropdown"] = current
 
-            selected_option = st.sidebar.selectbox(
+            default_idx = options.index(current) if current and current in options else 0
+
+            st.sidebar.selectbox(
                 "Previously clicked lakes:",
                 options,
                 index=default_idx,
                 label_visibility="collapsed",
                 help="Select a previously clicked lake",
                 format_func=lambda x: geohash_to_human_readable_name(x),
+                key="clicked_lakes_dropdown",
+                on_change=_on_clicked_lake_dropdown_change,
             )
-
-            # Update selection based on dropdown choice
-            if selected_option != st.session_state.selected_geohash:
-                st.session_state.selected_geohash = selected_option
-                st.query_params["selected_lake"] = selected_option
-                # change map params
-                clicked_lat, clicked_lon = pygeohash.decode(selected_option)
-                set_desired_view(clicked_lat, clicked_lon, 12)
-                st.session_state["_centered_selection"] = selected_option
-                st.rerun()
         else:
             st.sidebar.info("No features clicked yet. Click on a feature to select it.")
 
@@ -1490,6 +1493,9 @@ def create_app(
             st.sidebar.write(
                 f"**Current selection:** {geohash_to_human_readable_name(st.session_state.get('selected_geohash'))}"
             )
+            if st.sidebar.button("✖ Clear selection", key="clear_selected_lake"):
+                viewer.clear_selection()
+                st.rerun()
 
         # Time Series Plot Section
         if current:

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -390,6 +390,20 @@ class MapViewer:
         # Track the user's live view (feeds the shareable URL, not map construction)
         update_live_view(map_data.get("center"), map_data.get("zoom"))
 
+        # The click fields below echo the *last* click the frontend map widget saw,
+        # unchanged across reruns that weren't triggered by a new click (e.g. our
+        # own st.rerun() after clearing the selection). Comparing clicked_id against
+        # selected_geohash can't tell "stale echo of an old click" apart from "user
+        # clicked the same lake again", so track the raw click signature instead.
+        raw_click_signature = (
+            str(map_data.get("last_object_clicked")),
+            str(map_data.get("last_active_drawing")),
+            str(map_data.get("last_object_clicked_tooltip")),
+            str(map_data.get("last_clicked")),
+        )
+        is_new_click_event = raw_click_signature != st.session_state.get("_last_raw_click_signature_pmtiles")
+        st.session_state["_last_raw_click_signature_pmtiles"] = raw_click_signature
+
         # Extract clicked feature's id_geohash for time-series lookup
         clicked_id = None
         clicked_data = map_data.get("last_object_clicked")
@@ -429,8 +443,8 @@ class MapViewer:
                         st.session_state["_centered_selection"] = clicked_id
                         logger.info(f"Clicked on lake {clicked_id} and coordinate {clicked_lat} {clicked_lon}")
 
-        # Update session state only if a NEW feature was clicked
-        if clicked_id and clicked_id != st.session_state.get("selected_geohash"):
+        # Update session state only if this is a genuinely new click event
+        if clicked_id and is_new_click_event:
             st.session_state.selected_geohash = clicked_id
             st.query_params["selected_lake"] = clicked_id
             logger.info(f"New lake selected: {clicked_id}")
@@ -643,8 +657,16 @@ class MapViewer:
             if clicked_data and "properties" in clicked_data:
                 clicked_id = clicked_data["properties"].get(self.id_column)
 
-        # Update session state only if a NEW feature was clicked (not the same one)
-        if clicked_id and clicked_id != st.session_state.get("selected_geohash"):
+        # `last_active_drawing` echoes the last click unchanged across reruns that
+        # weren't triggered by a new click (e.g. our own st.rerun() after clearing
+        # the selection), so track the raw signature rather than diffing against
+        # selected_geohash directly -- see the matching fix in _render_pmtiles.
+        raw_click_signature = str(result.get("last_active_drawing")) if result else None
+        is_new_click_event = raw_click_signature != st.session_state.get("_last_raw_click_signature_folium")
+        st.session_state["_last_raw_click_signature_folium"] = raw_click_signature
+
+        # Update session state only if this is a genuinely new click event
+        if clicked_id and is_new_click_event:
             st.session_state.selected_geohash = clicked_id
             st.query_params["selected_lake"] = clicked_id
             if clicked_id not in st.session_state.clicked_features:
@@ -1451,9 +1473,15 @@ def create_app(
 
         clicked = viewer.get_clicked_features()
 
+        _DROPDOWN_NO_SELECTION = "__no_lake_selected__"
+
         def _on_clicked_lake_dropdown_change():
             selected_option = st.session_state.get("clicked_lakes_dropdown")
-            if selected_option and selected_option != st.session_state.get("selected_geohash"):
+            if (
+                selected_option
+                and selected_option != _DROPDOWN_NO_SELECTION
+                and selected_option != st.session_state.get("selected_geohash")
+            ):
                 st.session_state.selected_geohash = selected_option
                 st.query_params["selected_lake"] = selected_option
                 clicked_lat, clicked_lon = pygeohash.decode(selected_option)
@@ -1466,21 +1494,28 @@ def create_app(
             options = list(reversed(clicked))
             current = viewer.get_selected_geohash()
 
+            # A leading "no selection" sentinel so that after a clear, picking a
+            # lake is always a real value change to the widget (and thus fires
+            # on_change) even when there's only one previously-clicked lake and
+            # it's the same one that was just cleared.
+            display_options = [_DROPDOWN_NO_SELECTION, *options]
+            target_value = current if current and current in options else _DROPDOWN_NO_SELECTION
+
             # Keep the dropdown's own widget state in sync with selections made
             # elsewhere (map click, clear button) since a keyed widget otherwise
             # ignores `index` after its first render.
-            if current and current in options and st.session_state.get("clicked_lakes_dropdown") != current:
-                st.session_state["clicked_lakes_dropdown"] = current
-
-            default_idx = options.index(current) if current and current in options else 0
+            if st.session_state.get("clicked_lakes_dropdown") != target_value:
+                st.session_state["clicked_lakes_dropdown"] = target_value
 
             st.sidebar.selectbox(
                 "Previously clicked lakes:",
-                options,
-                index=default_idx,
+                display_options,
+                index=display_options.index(target_value),
                 label_visibility="collapsed",
                 help="Select a previously clicked lake",
-                format_func=lambda x: geohash_to_human_readable_name(x),
+                format_func=lambda x: (
+                    "No lake selected" if x == _DROPDOWN_NO_SELECTION else geohash_to_human_readable_name(x)
+                ),
                 key="clicked_lakes_dropdown",
                 on_change=_on_clicked_lake_dropdown_change,
             )

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -6,8 +6,12 @@ The dashboard keeps its restorable state in readable query params on its own URL
 
 Params at their default value are removed to keep URLs clean. When the app is
 embedded in an iframe on a cooperating parent site (see ``embed/``), the same
-params are mirrored onto the parent URL with a ``wt_`` prefix via postMessage,
-and the "Copy link" button produces a parent-site URL instead.
+params are mirrored onto the parent URL with a ``wt_`` prefix via postMessage.
+
+Two additional query params configure embedding behavior but are never part
+of the shareable state (set once by the embedding parent, not echoed back):
+``theme`` (``light``/``dark``, forces the color scheme) and ``show_share``
+(``false`` hides the "Copy link" button, e.g. when the parent offers its own).
 
 Map view state is two-tiered to avoid feedback loops with streamlit-folium:
 
@@ -41,6 +45,9 @@ PARENT_PARAM_PREFIX = "wt_"
 
 #: Env var restricting which parent origin the app will postMessage to.
 PARENT_ORIGIN_ENV = "WT_PARENT_ORIGIN"
+
+#: Valid values for the `theme` query param.
+_THEME_VALUES = ("light", "dark")
 
 _MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
 _GEOHASH_RE = re.compile(r"^[0-9a-zA-Z]{1,12}$")
@@ -246,6 +253,49 @@ def current_state_params() -> dict:
     return {key: st.query_params[key] for key in STATE_PARAM_KEYS if key in st.query_params}
 
 
+def share_button_enabled() -> bool:
+    """Whether the sidebar "Copy link" button should render.
+
+    An embedding parent that offers its own shareable link (e.g. MetacatUI,
+    see issue #2841) can pass ``show_share=false`` to hide this app's button.
+    """
+    return st.query_params.get("show_share", "true").strip().lower() not in ("false", "0")
+
+
+def apply_theme_param() -> None:
+    """Force Streamlit's embed theme from a ``theme=light|dark`` query param.
+
+    ``embed``/``embed_options`` are invisible to ``st.query_params`` (Streamlit's
+    frontend reads them straight off the URL before Python ever runs), so
+    forcing a theme requires a one-time client-side redirect that appends
+    ``embed_options=<theme>_theme`` (and ``embed=true``) to the URL. The JS
+    checks the *browser* URL (not st.query_params) before redirecting, so it
+    only fires once even though this runs on every rerun.
+    """
+    theme = st.query_params.get("theme")
+    if theme not in _THEME_VALUES:
+        return
+    st.markdown(
+        f"""
+        <script>
+        (function() {{
+            var params = new URLSearchParams(window.location.search);
+            if (params.getAll("embed_options").indexOf("{theme}_theme") === -1) {{
+                params.append("embed_options", "{theme}_theme");
+                if (params.getAll("embed").indexOf("true") === -1) {{
+                    params.append("embed", "true");
+                }}
+                window.location.replace(
+                    window.location.pathname + "?" + params.toString() + window.location.hash
+                );
+            }}
+        }})();
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
 def _target_origin() -> str:
     return os.environ.get(PARENT_ORIGIN_ENV) or "*"
 
@@ -342,6 +392,8 @@ def render_copy_link_button() -> None:
                 var u = new URL(base);
                 u.searchParams.delete("embed");
                 u.searchParams.delete("embed_options");
+                u.searchParams.delete("theme");
+                u.searchParams.delete("show_share");
                 CFG.stateKeys.forEach(function(k) { u.searchParams.delete(k); });
                 Object.keys(params).forEach(function(k) { u.searchParams.set(k, params[k]); });
                 return u.toString();

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -1,0 +1,410 @@
+"""Shareable-link state: sync window state (map view, toggles, selection) with URL query params.
+
+The dashboard keeps its restorable state in readable query params on its own URL:
+
+    ?selected_lake=<geohash>&lat=<f>&lon=<f>&zoom=<f>&drained=1&month=YYYY-MM&hide_stable=1
+
+Params at their default value are removed to keep URLs clean. When the app is
+embedded in an iframe on a cooperating parent site (see ``embed/``), the same
+params are mirrored onto the parent URL with a ``wt_`` prefix via postMessage,
+and the "Copy link" button produces a parent-site URL instead.
+
+Map view state is two-tiered to avoid feedback loops with streamlit-folium:
+
+- Construction keys (``map_center``/``zoom_level``) are baked into the folium
+  HTML; changing them remounts the Leaflet map, so they may only change on full
+  reruns (programmatic jumps, URL restore, live-view adoption).
+- Live keys (``live_map_center``/``live_map_zoom``) mirror what the user
+  actually sees (captured from ``st_folium``'s returned center/zoom on fragment
+  reruns); they feed the URL but never the fragment's map construction.
+"""
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+import pygeohash
+import streamlit as st
+
+# Defaults matching create_app's initial view; params equal to these are elided.
+DEFAULT_LAT = 66.5
+DEFAULT_LON = -164.1
+DEFAULT_ZOOM = 10.0
+
+#: All query-param keys owned by this module (plus the pre-existing selected_lake).
+STATE_PARAM_KEYS = ("selected_lake", "lat", "lon", "zoom", "drained", "month", "hide_stable")
+
+#: Prefix applied to state params when mirrored onto a parent site's URL.
+PARENT_PARAM_PREFIX = "wt_"
+
+#: Env var restricting which parent origin the app will postMessage to.
+PARENT_ORIGIN_ENV = "WT_PARENT_ORIGIN"
+
+_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+_GEOHASH_RE = re.compile(r"^[0-9a-zA-Z]{1,12}$")
+
+_COORD_EPS = 1e-5
+_ZOOM_EPS = 0.01
+
+
+@dataclass
+class UrlState:
+    """Decoded, validated window state from URL query params."""
+
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    zoom: Optional[float] = None
+    selected_lake: Optional[str] = None
+    drained: bool = False
+    month: Optional[str] = None
+    hide_stable: bool = False
+
+
+def _parse_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if result != result or result in (float("inf"), float("-inf")):  # NaN/inf guard
+        return None
+    return result
+
+
+def decode_url_state(params: Mapping[str, str]) -> UrlState:
+    """Parse query params into a UrlState, silently dropping malformed values."""
+    lat = _parse_float(params.get("lat"))
+    lon = _parse_float(params.get("lon"))
+    zoom = _parse_float(params.get("zoom"))
+    if lat is not None and not -90 <= lat <= 90:
+        lat = None
+    if lon is not None and not -180 <= lon <= 180:
+        lon = None
+    if zoom is not None and not 0 <= zoom <= 24:
+        zoom = None
+
+    selected_lake = params.get("selected_lake")
+    if selected_lake and not _GEOHASH_RE.match(str(selected_lake)):
+        selected_lake = None
+
+    month = params.get("month")
+    if month and not _MONTH_RE.match(str(month)):
+        month = None
+
+    return UrlState(
+        lat=lat,
+        lon=lon,
+        zoom=zoom,
+        selected_lake=str(selected_lake) if selected_lake else None,
+        drained=params.get("drained") == "1",
+        month=str(month) if month else None,
+        hide_stable=params.get("hide_stable") == "1",
+    )
+
+
+def _fmt(value: float, decimals: int) -> str:
+    text = f"{value:.{decimals}f}".rstrip("0").rstrip(".")
+    return text if text not in ("", "-0") else "0"
+
+
+def encode_view(lat: float, lon: float, zoom: float) -> dict:
+    """Round view values to URL precision (lat/lon 5 dp ~1 m, zoom 2 dp)."""
+    return {"lat": _fmt(lat, 5), "lon": _fmt(lon, 5), "zoom": _fmt(zoom, 2)}
+
+
+def _view_is_default(lat: float, lon: float, zoom: float) -> bool:
+    return (
+        abs(lat - DEFAULT_LAT) < _COORD_EPS
+        and abs(lon - DEFAULT_LON) < _COORD_EPS
+        and abs(zoom - DEFAULT_ZOOM) < _ZOOM_EPS
+    )
+
+
+def _write_view_params(lat: float, lon: float, zoom: float) -> None:
+    if _view_is_default(lat, lon, zoom):
+        for key in ("lat", "lon", "zoom"):
+            st.query_params.pop(key, None)
+        return
+    encoded = encode_view(lat, lon, zoom)
+    for key, value in encoded.items():
+        if st.query_params.get(key) != value:
+            st.query_params[key] = value
+
+
+def sync_flag_param(name: str, on: bool) -> None:
+    """Keep a boolean query param in sync: '1' when on, absent when off."""
+    if on:
+        if st.query_params.get(name) != "1":
+            st.query_params[name] = "1"
+    else:
+        st.query_params.pop(name, None)
+
+
+def set_desired_view(lat: float, lon: float, zoom: float) -> None:
+    """Programmatic jump: set construction keys, live keys, and URL params.
+
+    Single choke point for all programmatic view changes (lake selection, URL
+    restore). Writing the live keys too prevents a stale live view from
+    clobbering the jump when the next full run adopts live state.
+    """
+    st.session_state.map_center = {"lat": lat, "lon": lon}
+    st.session_state.zoom_level = zoom
+    st.session_state.live_map_center = {"lat": lat, "lon": lon}
+    st.session_state.live_map_zoom = zoom
+    _write_view_params(lat, lon, zoom)
+
+
+def update_live_view(center: Optional[Mapping], zoom: Optional[float]) -> None:
+    """Record the user's live view (from st_folium) without touching map construction.
+
+    Called on fragment reruns after pan/zoom. Only updates live keys and URL
+    params, so the folium HTML is unchanged and the map does not remount.
+    """
+    if not center:
+        return
+    lat = center.get("lat")
+    lon = center.get("lng", center.get("lon"))
+    if lat is None or lon is None:
+        return
+    if zoom is None:
+        zoom = st.session_state.get("live_map_zoom", st.session_state.get("zoom_level", DEFAULT_ZOOM))
+
+    prev_center = st.session_state.get("live_map_center") or {}
+    prev_zoom = st.session_state.get("live_map_zoom")
+    unchanged = (
+        prev_zoom is not None
+        and abs(lat - prev_center.get("lat", 1e9)) < _COORD_EPS
+        and abs(lon - prev_center.get("lon", 1e9)) < _COORD_EPS
+        and abs(zoom - prev_zoom) < _ZOOM_EPS
+    )
+    if unchanged:
+        return
+
+    st.session_state.live_map_center = {"lat": lat, "lon": lon}
+    st.session_state.live_map_zoom = zoom
+    _write_view_params(lat, lon, zoom)
+
+
+def adopt_live_view() -> None:
+    """On a full run, rebuild the map at the user's live view (if it moved).
+
+    Copies live keys into construction keys so the rebuilt folium map is
+    already positioned where the user left it.
+    """
+    live_center = st.session_state.get("live_map_center")
+    live_zoom = st.session_state.get("live_map_zoom")
+    if live_center is not None:
+        st.session_state.map_center = dict(live_center)
+    if live_zoom is not None:
+        st.session_state.zoom_level = live_zoom
+
+
+def apply_url_state_once() -> None:
+    """Restore window state from URL query params (once per session).
+
+    Must run in create_app BEFORE the recenter-to-selection block and before
+    any widget it seeds (show_drained_toggle, toggle_hide_stable_lakes,
+    heatmap_selected_cell) is instantiated.
+    """
+    if st.session_state.get("_url_state_applied"):
+        return
+    st.session_state["_url_state_applied"] = True
+
+    state = decode_url_state(st.query_params)
+
+    if state.lat is not None and state.lon is not None:
+        set_desired_view(state.lat, state.lon, state.zoom if state.zoom is not None else DEFAULT_ZOOM)
+        if state.selected_lake:
+            # The shared live view wins over the automatic zoom-12 recenter.
+            st.session_state["_centered_selection"] = state.selected_lake
+    elif state.selected_lake:
+        try:
+            glat, glon = pygeohash.decode(state.selected_lake)
+            set_desired_view(glat, glon, 12)
+            st.session_state["_centered_selection"] = state.selected_lake
+        except Exception:
+            pass
+
+    if state.drained:
+        st.session_state["show_drained_toggle"] = True
+        # Suppress the one-time zoom-6 drainage-overview override on restore.
+        st.session_state["_prev_show_drained"] = True
+
+    if state.month:
+        st.session_state["heatmap_selected_cell"] = state.month
+        st.session_state["heatmap_sync_dropdown"] = True
+
+    if state.hide_stable:
+        st.session_state["toggle_hide_stable_lakes"] = True
+
+
+def current_state_params() -> dict:
+    """Current shareable-state params from the URL (source of truth for sharing)."""
+    return {key: st.query_params[key] for key in STATE_PARAM_KEYS if key in st.query_params}
+
+
+def _target_origin() -> str:
+    return os.environ.get(PARENT_ORIGIN_ENV) or "*"
+
+
+def render_state_bridge() -> None:
+    """Post the current state params to a cooperating parent page (wt:state).
+
+    Rendered inside the map fragment so pan/zoom fragment reruns re-post. The
+    component only re-executes when its HTML (i.e. the params JSON) changes,
+    so unchanged state produces no message spam. Harmless when not framed.
+    """
+    params_json = json.dumps(current_state_params(), sort_keys=True)
+    target_json = json.dumps(_target_origin())
+    st.iframe(
+        f"""
+        <script>
+        (function() {{
+            try {{
+                window.top.postMessage(
+                    {{ type: "wt:state", version: 1, params: {params_json} }},
+                    {target_json}
+                );
+            }} catch (e) {{ /* not framed or origin mismatch: nothing to do */ }}
+        }})();
+        </script>
+        """,
+        height=1,
+    )
+
+
+def render_copy_link_button() -> None:
+    """Sidebar "Copy link" button restoring the exact window state.
+
+    Standalone: copies the app's own URL (embed params stripped). Inside an
+    iframe on a cooperating parent page (which answers wt:hello with
+    wt:hello-ack), copies a parent-site URL carrying wt_-prefixed params.
+    Falls back to a selectable text input when the clipboard is unavailable.
+    """
+    fallback_params_json = json.dumps(current_state_params(), sort_keys=True)
+    app_url = ""
+    try:
+        app_url = str(st.context.url or "")
+    except Exception:
+        pass
+    config = json.dumps(
+        {
+            "fallbackParams": json.loads(fallback_params_json),
+            "fallbackAppUrl": app_url,
+            "targetOrigin": _target_origin(),
+            "stateKeys": list(STATE_PARAM_KEYS),
+        }
+    )
+    st.iframe(
+        """
+        <style>
+            body { margin: 0; font-family: "Source Sans Pro", sans-serif; }
+            #wt-copy {
+                width: 100%; padding: 0.4rem 0.75rem; cursor: pointer;
+                border: 1px solid rgba(49, 51, 63, 0.2); border-radius: 0.5rem;
+                background: transparent; color: inherit; font-size: 0.875rem;
+            }
+            #wt-copy:hover { border-color: #ff4b4b; color: #ff4b4b; }
+            #wt-url {
+                width: 100%; margin-top: 0.25rem; padding: 0.25rem;
+                font-size: 0.75rem; box-sizing: border-box; display: none;
+            }
+            @media (prefers-color-scheme: dark) {
+                #wt-copy { border-color: rgba(250, 250, 250, 0.2); color: #fafafa; }
+            }
+        </style>
+        <button id="wt-copy" title="Copy a link that restores this exact view">🔗 Copy link to this view</button>
+        <input id="wt-url" readonly>
+        <script>
+        (function() {
+            var CFG = __WT_CONFIG__;
+            var parentInfo = null;
+
+            window.addEventListener("message", function(ev) {
+                var d = ev.data;
+                if (!d || d.type !== "wt:hello-ack") return;
+                if (CFG.targetOrigin !== "*" && ev.origin !== CFG.targetOrigin) return;
+                parentInfo = { href: d.href, prefix: d.prefix || "wt_" };
+            });
+            try {
+                window.top.postMessage({ type: "wt:hello", version: 1 }, CFG.targetOrigin);
+            } catch (e) {}
+
+            function currentParams() {
+                try {
+                    var sp = new URLSearchParams(window.parent.location.search);
+                    var out = {};
+                    CFG.stateKeys.forEach(function(k) {
+                        var v = sp.get(k);
+                        if (v !== null) out[k] = v;
+                    });
+                    return out;
+                } catch (e) {
+                    return CFG.fallbackParams;
+                }
+            }
+
+            function buildUrl() {
+                var params = currentParams();
+                if (parentInfo && parentInfo.href) {
+                    var u = new URL(parentInfo.href);
+                    var stale = [];
+                    u.searchParams.forEach(function(v, k) {
+                        if (k.indexOf(parentInfo.prefix) === 0) stale.push(k);
+                    });
+                    stale.forEach(function(k) { u.searchParams.delete(k); });
+                    Object.keys(params).forEach(function(k) {
+                        u.searchParams.set(parentInfo.prefix + k, params[k]);
+                    });
+                    return u.toString();
+                }
+                var base = CFG.fallbackAppUrl;
+                try { base = window.parent.location.href; } catch (e) {}
+                if (!base) return null;
+                var u2 = new URL(base);
+                u2.searchParams.delete("embed");
+                u2.searchParams.delete("embed_options");
+                CFG.stateKeys.forEach(function(k) { u2.searchParams.delete(k); });
+                Object.keys(params).forEach(function(k) { u2.searchParams.set(k, params[k]); });
+                return u2.toString();
+            }
+
+            var btn = document.getElementById("wt-copy");
+            var inp = document.getElementById("wt-url");
+            function flash(text) {
+                var old = "🔗 Copy link to this view";
+                btn.textContent = text;
+                setTimeout(function() { btn.textContent = old; }, 1600);
+            }
+            function showFallback(url) {
+                inp.style.display = "block";
+                inp.value = url;
+                inp.focus();
+                inp.select();
+                try {
+                    document.execCommand("copy");
+                    flash("✓ Copied!");
+                } catch (e) {
+                    flash("Press Ctrl/Cmd+C to copy");
+                }
+            }
+            btn.addEventListener("click", function() {
+                var url = buildUrl();
+                if (!url) { flash("No URL available"); return; }
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(url).then(
+                        function() { flash("✓ Copied!"); },
+                        function() { showFallback(url); }
+                    );
+                } else {
+                    showFallback(url);
+                }
+            });
+        })();
+        </script>
+        """.replace("__WT_CONFIG__", config),
+        height=70,
+    )

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -271,28 +271,35 @@ def apply_theme_param() -> None:
     ``embed_options=<theme>_theme`` (and ``embed=true``) to the URL. The JS
     checks the *browser* URL (not st.query_params) before redirecting, so it
     only fires once even though this runs on every rerun.
+
+    Rendered via ``st.iframe`` (not ``st.markdown``): scripts injected through
+    ``st.markdown``'s HTML are inert (browsers don't execute ``<script>`` tags
+    inserted via innerHTML), while ``st.iframe`` renders a real document whose
+    scripts do run. The script itself targets ``window.top.location`` since it
+    executes inside that iframe, one level below the app page it needs to
+    redirect.
     """
     theme = st.query_params.get("theme")
     if theme not in _THEME_VALUES:
         return
-    st.markdown(
+    st.iframe(
         f"""
         <script>
         (function() {{
-            var params = new URLSearchParams(window.location.search);
+            var params = new URLSearchParams(window.top.location.search);
             if (params.getAll("embed_options").indexOf("{theme}_theme") === -1) {{
                 params.append("embed_options", "{theme}_theme");
                 if (params.getAll("embed").indexOf("true") === -1) {{
                     params.append("embed", "true");
                 }}
-                window.location.replace(
-                    window.location.pathname + "?" + params.toString() + window.location.hash
+                window.top.location.replace(
+                    window.top.location.pathname + "?" + params.toString() + window.top.location.hash
                 );
             }}
         }})();
         </script>
         """,
-        unsafe_allow_html=True,
+        height=1,
     )
 
 

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -319,7 +319,6 @@ def render_copy_link_button() -> None:
         <script>
         (function() {
             var CFG = __WT_CONFIG__;
-            var parentInfo = null;
 
             function currentParams() {
                 try {
@@ -337,27 +336,15 @@ def render_copy_link_button() -> None:
 
             function buildUrl() {
                 var params = currentParams();
-                if (parentInfo && parentInfo.href) {
-                    var u = new URL(parentInfo.href);
-                    var stale = [];
-                    u.searchParams.forEach(function(v, k) {
-                        if (k.indexOf(parentInfo.prefix) === 0) stale.push(k);
-                    });
-                    stale.forEach(function(k) { u.searchParams.delete(k); });
-                    Object.keys(params).forEach(function(k) {
-                        u.searchParams.set(parentInfo.prefix + k, params[k]);
-                    });
-                    return u.toString();
-                }
                 var base = CFG.fallbackAppUrl;
                 try { base = window.parent.location.href; } catch (e) {}
                 if (!base) return null;
-                var u2 = new URL(base);
-                u2.searchParams.delete("embed");
-                u2.searchParams.delete("embed_options");
-                CFG.stateKeys.forEach(function(k) { u2.searchParams.delete(k); });
-                Object.keys(params).forEach(function(k) { u2.searchParams.set(k, params[k]); });
-                return u2.toString();
+                var u = new URL(base);
+                u.searchParams.delete("embed");
+                u.searchParams.delete("embed_options");
+                CFG.stateKeys.forEach(function(k) { u.searchParams.delete(k); });
+                Object.keys(params).forEach(function(k) { u.searchParams.set(k, params[k]); });
+                return u.toString();
             }
 
             var btn = document.getElementById("wt-copy");

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -262,44 +262,85 @@ def share_button_enabled() -> bool:
     return st.query_params.get("show_share", "true").strip().lower() not in ("false", "0")
 
 
+#: Dark-mode palette, sourced from the ADC/MetacatUI dark portal theme
+#: (NCEAS/metacatui src/css/portal-themes/dark.css) so embedded dark mode
+#: matches the parent site's own dark theme instead of inventing one.
+_DARK_PALETTE = {
+    "background": "#111827",  # --portal-col-bkg__deprecate
+    "surface": "#1f2937",  # --portal-col-bkg-lighter__deprecate
+    "sidebar_background": "#374151",  # --portal-col-bkg-active__deprecate
+    "text": "#f9fafb",  # --portal-col-text__deprecate
+    "text_subtle": "#9ca3af",  # --portal-col-text-subtle__deprecate
+    "accent": "#269fb9",  # --portal-col-highlight__deprecate
+    "accent_subtle": "#0c4e66",  # --portal-col-highlight-subtle__deprecate
+}
+
+
 def apply_theme_param() -> None:
-    """Force Streamlit's embed theme from a ``theme=light|dark`` query param.
+    """Force a dark color scheme from a ``theme=light|dark`` query param.
 
-    ``embed``/``embed_options`` are invisible to ``st.query_params`` (Streamlit's
-    frontend reads them straight off the URL before Python ever runs), so
-    forcing a theme requires a one-time client-side redirect that appends
-    ``embed_options=<theme>_theme`` (and ``embed=true``) to the URL. The JS
-    checks the *browser* URL (not st.query_params) before redirecting, so it
-    only fires once even though this runs on every rerun.
+    Streamlit's own ``embed_options=light_theme|dark_theme`` can't be used
+    for this: it's invisible to ``st.query_params`` (the frontend reads it
+    straight off the URL before Python ever runs) and previously required a
+    client-side redirect to inject, but that redirect ran inside a sandboxed
+    ``st.iframe`` (no ``allow-top-navigation``) targeting ``window.top`` --
+    which, once this app is itself framed on a parent site, is the *parent's*
+    page rather than this app, so the navigation was both refused by the
+    sandbox and aimed at the wrong document. Separately, Streamlit silently
+    ignores ``embed_options`` theme switching whenever a custom ``[theme]`` is
+    configured (streamlit/streamlit#13496, fixed in 1.53.0) -- and this app
+    always has one, since the light theme is our ADC branding.
 
-    Rendered via ``st.iframe`` (not ``st.markdown``): scripts injected through
-    ``st.markdown``'s HTML are inert (browsers don't execute ``<script>`` tags
-    inserted via innerHTML), while ``st.iframe`` renders a real document whose
-    scripts do run. The script itself targets ``window.top.location`` since it
-    executes inside that iframe, one level below the app page it needs to
-    redirect.
+    ``theme`` is a plain, non-reserved query param, so Python sees it
+    directly via ``st.query_params`` with no redirect needed. Dark mode is
+    applied ourselves via an injected stylesheet (recoloring the app's own
+    surfaces to the ADC/MetacatUI dark palette) rather than delegating to
+    Streamlit's theme engine, so it doesn't depend on that engine's behavior
+    at all.
     """
     theme = st.query_params.get("theme")
-    if theme not in _THEME_VALUES:
+    if theme != "dark":
         return
-    st.iframe(
+    p = _DARK_PALETTE
+    st.markdown(
         f"""
-        <script>
-        (function() {{
-            var params = new URLSearchParams(window.top.location.search);
-            if (params.getAll("embed_options").indexOf("{theme}_theme") === -1) {{
-                params.append("embed_options", "{theme}_theme");
-                if (params.getAll("embed").indexOf("true") === -1) {{
-                    params.append("embed", "true");
-                }}
-                window.top.location.replace(
-                    window.top.location.pathname + "?" + params.toString() + window.top.location.hash
-                );
-            }}
-        }})();
-        </script>
+        <style>
+        [data-testid="stApp"], [data-testid="stAppViewContainer"],
+        [data-testid="stMain"], [data-testid="stHeader"] {{
+            background-color: {p["background"]};
+            color: {p["text"]};
+        }}
+        [data-testid="stSidebar"], [data-testid="stSidebarContent"] {{
+            background-color: {p["sidebar_background"]};
+            color: {p["text"]};
+        }}
+        [data-testid="stMainBlockContainer"] [data-testid="stMarkdownContainer"],
+        [data-testid="stWidgetLabel"], [data-testid="stText"] {{
+            color: {p["text"]};
+        }}
+        [data-testid="stExpander"], [data-testid="stTab"] {{
+            background-color: {p["surface"]};
+            color: {p["text"]};
+        }}
+        [data-testid="stDialog"] > div > div {{
+            background-color: {p["surface"]} !important;
+            color: {p["text"]} !important;
+        }}
+        [data-testid^="stBaseButton-"] {{
+            background-color: {p["surface"]};
+            color: {p["text"]};
+            border-color: {p["accent_subtle"]};
+        }}
+        [data-testid^="stBaseButton-primary"] {{
+            background-color: {p["accent"]};
+            color: {p["text"]};
+        }}
+        a, [data-testid^="stBaseButton-"]:hover {{
+            color: {p["accent"]};
+        }}
+        </style>
         """,
-        height=1,
+        unsafe_allow_html=True,
     )
 
 

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -265,7 +265,7 @@ def render_state_bridge() -> None:
         (function() {{
             try {{
                 window.top.postMessage(
-                    {{ type: "wt:state", version: 1, params: {params_json} }},
+                    {{ type: "mcui:state", version: 1, params: {params_json} }},
                     {target_json}
                 );
             }} catch (e) {{ /* not framed or origin mismatch: nothing to do */ }}
@@ -279,10 +279,8 @@ def render_state_bridge() -> None:
 def render_copy_link_button() -> None:
     """Sidebar "Copy link" button restoring the exact window state.
 
-    Standalone: copies the app's own URL (embed params stripped). Inside an
-    iframe on a cooperating parent page (which answers wt:hello with
-    wt:hello-ack), copies a parent-site URL carrying wt_-prefixed params.
-    Falls back to a selectable text input when the clipboard is unavailable.
+    Copies the app's own URL (embed params stripped). Falls back to a
+    selectable text input when the clipboard is unavailable.
     """
     fallback_params_json = json.dumps(current_state_params(), sort_keys=True)
     app_url = ""
@@ -322,16 +320,6 @@ def render_copy_link_button() -> None:
         (function() {
             var CFG = __WT_CONFIG__;
             var parentInfo = null;
-
-            window.addEventListener("message", function(ev) {
-                var d = ev.data;
-                if (!d || d.type !== "wt:hello-ack") return;
-                if (CFG.targetOrigin !== "*" && ev.origin !== CFG.targetOrigin) return;
-                parentInfo = { href: d.href, prefix: d.prefix || "wt_" };
-            });
-            try {
-                window.top.postMessage({ type: "wt:hello", version: 1 }, CFG.targetOrigin);
-            } catch (e) {}
 
             function currentParams() {
                 try {

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -28,6 +28,7 @@ import os
 import re
 from dataclasses import dataclass
 from typing import Mapping, Optional
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import pygeohash
 import streamlit as st
@@ -253,6 +254,23 @@ def current_state_params() -> dict:
     return {key: st.query_params[key] for key in STATE_PARAM_KEYS if key in st.query_params}
 
 
+def current_state_url() -> str:
+    """This app's own URL rebuilt with only the shareable state params.
+
+    Excludes embed-config params (``theme``, ``show_share``, ``embed``,
+    ``embed_options``) -- those are set once by the embedding parent and are
+    never echoed back into shared state.
+    """
+    try:
+        base = str(st.context.url or "")
+    except Exception:
+        base = ""
+    if not base:
+        return ""
+    scheme, netloc, path, _, _ = urlsplit(base)
+    return urlunsplit((scheme, netloc, path, urlencode(current_state_params()), ""))
+
+
 def share_button_enabled() -> bool:
     """Whether the sidebar "Copy link" button should render.
 
@@ -349,13 +367,17 @@ def _target_origin() -> str:
 
 
 def render_state_bridge() -> None:
-    """Post the current state params to a cooperating parent page (wt:state).
+    """Post this app's current state URL to a cooperating parent page (mcui:state).
 
     Rendered inside the map fragment so pan/zoom fragment reruns re-post. The
-    component only re-executes when its HTML (i.e. the params JSON) changes,
-    so unchanged state produces no message spam. Harmless when not framed.
+    component only re-executes when its HTML (i.e. the URL) changes, so
+    unchanged state produces no message spam. Harmless when not framed.
+
+    The parent receives a plain URL rather than a bespoke params object, so it
+    can extract and whitelist state itself (e.g. via an RFC 6570 URI template
+    it already owns) instead of MetacatUI hardcoding this app's param names.
     """
-    params_json = json.dumps(current_state_params(), sort_keys=True)
+    url_json = json.dumps(current_state_url())
     target_json = json.dumps(_target_origin())
     st.iframe(
         f"""
@@ -363,7 +385,7 @@ def render_state_bridge() -> None:
         (function() {{
             try {{
                 window.top.postMessage(
-                    {{ type: "mcui:state", version: 1, params: {params_json} }},
+                    {{ type: "mcui:state", version: 1, url: {url_json} }},
                     {target_json}
                 );
             }} catch (e) {{ /* not framed or origin mismatch: nothing to do */ }}

--- a/src/water_timeseries/dashboard/share_state.py
+++ b/src/water_timeseries/dashboard/share_state.py
@@ -24,10 +24,11 @@ Map view state is two-tiered to avoid feedback loops with streamlit-folium:
 """
 
 import json
+import math
 import os
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping, Optional
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import pygeohash
@@ -61,23 +62,23 @@ _ZOOM_EPS = 0.01
 class UrlState:
     """Decoded, validated window state from URL query params."""
 
-    lat: Optional[float] = None
-    lon: Optional[float] = None
-    zoom: Optional[float] = None
-    selected_lake: Optional[str] = None
+    lat: float | None = None
+    lon: float | None = None
+    zoom: float | None = None
+    selected_lake: str | None = None
     drained: bool = False
-    month: Optional[str] = None
+    month: str | None = None
     hide_stable: bool = False
 
 
-def _parse_float(value: Optional[str]) -> Optional[float]:
+def _parse_float(value: str | None) -> float | None:
     if value is None:
         return None
     try:
         result = float(value)
     except (TypeError, ValueError):
         return None
-    if result != result or result in (float("inf"), float("-inf")):  # NaN/inf guard
+    if not math.isfinite(result):  # NaN/inf guard
         return None
     return result
 
@@ -165,7 +166,7 @@ def set_desired_view(lat: float, lon: float, zoom: float) -> None:
     _write_view_params(lat, lon, zoom)
 
 
-def update_live_view(center: Optional[Mapping], zoom: Optional[float]) -> None:
+def update_live_view(center: Mapping | None, zoom: float | None) -> None:
     """Record the user's live view (from st_folium) without touching map construction.
 
     Called on fragment reruns after pan/zoom. Only updates live keys and URL
@@ -233,7 +234,7 @@ def apply_url_state_once() -> None:
             glat, glon = pygeohash.decode(state.selected_lake)
             set_desired_view(glat, glon, 12)
             st.session_state["_centered_selection"] = state.selected_lake
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     if state.drained:
@@ -263,7 +264,7 @@ def current_state_url() -> str:
     """
     try:
         base = str(st.context.url or "")
-    except Exception:
+    except Exception:  # noqa: BLE001
         base = ""
     if not base:
         return ""
@@ -406,7 +407,7 @@ def render_copy_link_button() -> None:
     app_url = ""
     try:
         app_url = str(st.context.url or "")
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     config = json.dumps(
         {

--- a/tests/test_share_state.py
+++ b/tests/test_share_state.py
@@ -1,0 +1,156 @@
+"""Tests for shareable-link state encoding/decoding (dashboard.share_state)."""
+
+import pygeohash
+from streamlit.testing.v1 import AppTest
+
+from water_timeseries.dashboard.share_state import (
+    DEFAULT_LAT,
+    DEFAULT_LON,
+    DEFAULT_ZOOM,
+    UrlState,
+    decode_url_state,
+    encode_view,
+)
+
+
+class TestEncodeView:
+    def test_rounds_lat_lon_to_5_decimals(self):
+        encoded = encode_view(66.5123456789, -164.0876543, 12)
+        assert encoded["lat"] == "66.51235"
+        assert encoded["lon"] == "-164.08765"
+
+    def test_rounds_zoom_to_2_decimals(self):
+        assert encode_view(66.5, -164.1, 7.4361)["zoom"] == "7.44"
+
+    def test_strips_trailing_zeros(self):
+        encoded = encode_view(66.5, -164.0, 12.0)
+        assert encoded == {"lat": "66.5", "lon": "-164", "zoom": "12"}
+
+    def test_zero_values(self):
+        encoded = encode_view(0.0, 0.0, 0.0)
+        assert encoded == {"lat": "0", "lon": "0", "zoom": "0"}
+
+
+class TestDecodeUrlState:
+    def test_empty_params(self):
+        state = decode_url_state({})
+        assert state == UrlState()
+        assert state.lat is None and state.drained is False
+
+    def test_full_valid_params(self):
+        state = decode_url_state(
+            {
+                "selected_lake": "b7zpm2xq4k9d",
+                "lat": "66.512",
+                "lon": "-164.087",
+                "zoom": "12",
+                "drained": "1",
+                "month": "2024-06",
+                "hide_stable": "1",
+            }
+        )
+        assert state.selected_lake == "b7zpm2xq4k9d"
+        assert state.lat == 66.512
+        assert state.lon == -164.087
+        assert state.zoom == 12
+        assert state.drained is True
+        assert state.month == "2024-06"
+        assert state.hide_stable is True
+
+    def test_malformed_floats_dropped(self):
+        state = decode_url_state({"lat": "abc", "lon": "1e999", "zoom": "nan"})
+        assert state.lat is None and state.lon is None and state.zoom is None
+
+    def test_out_of_range_coords_dropped(self):
+        state = decode_url_state({"lat": "95", "lon": "-200", "zoom": "50"})
+        assert state.lat is None and state.lon is None and state.zoom is None
+
+    def test_bad_month_dropped(self):
+        for bad in ("2024-6", "202406", "June 2024", "2024-06-01", "<script>"):
+            assert decode_url_state({"month": bad}).month is None
+
+    def test_good_month_kept(self):
+        assert decode_url_state({"month": "2019-11"}).month == "2019-11"
+
+    def test_bad_geohash_dropped(self):
+        for bad in ("b7zpm2xq4k9d0", "geo hash!", "a/b", ""):
+            assert decode_url_state({"selected_lake": bad}).selected_lake is None
+
+    def test_flags_only_accept_1(self):
+        state = decode_url_state({"drained": "true", "hide_stable": "yes"})
+        assert state.drained is False and state.hide_stable is False
+
+
+class TestRoundTrip:
+    def test_encode_decode_round_trip(self):
+        encoded = encode_view(66.51234, -164.08765, 11.5)
+        state = decode_url_state(encoded)
+        assert state.lat == 66.51234
+        assert state.lon == -164.08765
+        assert state.zoom == 11.5
+
+    def test_defaults_round_trip(self):
+        encoded = encode_view(DEFAULT_LAT, DEFAULT_LON, DEFAULT_ZOOM)
+        state = decode_url_state(encoded)
+        assert state.lat == DEFAULT_LAT
+        assert state.lon == DEFAULT_LON
+        assert state.zoom == DEFAULT_ZOOM
+
+
+def _restore_app():
+    import streamlit as st
+
+    from water_timeseries.dashboard.share_state import apply_url_state_once
+
+    apply_url_state_once()
+    st.write("ok")
+
+
+class TestApplyUrlStateOnce:
+    def test_full_url_state_seeds_session_state(self):
+        at = AppTest.from_function(_restore_app, default_timeout=60)
+        for key, value in {
+            "lat": "66.512",
+            "lon": "-164.087",
+            "zoom": "12",
+            "drained": "1",
+            "month": "2024-06",
+            "hide_stable": "1",
+            "selected_lake": "b7zpm2xq4k9d",
+        }.items():
+            at.query_params[key] = value
+        at.run()
+        assert not at.exception
+        ss = at.session_state
+        assert ss["map_center"] == {"lat": 66.512, "lon": -164.087}
+        assert ss["zoom_level"] == 12.0
+        assert ss["live_map_zoom"] == 12.0
+        assert ss["show_drained_toggle"] is True
+        # zoom-6 drainage-overview override must be suppressed on restore
+        assert ss["_prev_show_drained"] is True
+        assert ss["heatmap_selected_cell"] == "2024-06"
+        assert ss["heatmap_sync_dropdown"] is True
+        assert ss["toggle_hide_stable_lakes"] is True
+        # the shared live view wins over the automatic zoom-12 recenter
+        assert ss["_centered_selection"] == "b7zpm2xq4k9d"
+
+    def test_selected_lake_only_centers_at_zoom_12(self):
+        geohash = pygeohash.encode(67.1, -160.2, precision=12)
+        at = AppTest.from_function(_restore_app, default_timeout=60)
+        at.query_params["selected_lake"] = geohash
+        at.run()
+        assert not at.exception
+        ss = at.session_state
+        assert ss["zoom_level"] == 12
+        assert abs(ss["map_center"]["lat"] - 67.1) < 1e-6
+        assert abs(ss["map_center"]["lon"] + 160.2) < 1e-6
+        assert ss["_centered_selection"] == geohash
+
+    def test_no_params_is_a_noop(self):
+        at = AppTest.from_function(_restore_app, default_timeout=60)
+        at.run()
+        assert not at.exception
+        ss = at.session_state
+        assert "map_center" not in ss
+        assert "show_drained_toggle" not in ss
+        assert ss["_url_state_applied"] is True


### PR DESCRIPTION
**Summary**

Adds shareable deep links to the dashboard. Copying the URL (address bar or the new sidebar **🔗 Copy link to this view** button) produces a link that restores the exact window state: live map center/zoom, selected lake, Historical Drainage toggle + analysis month, and Hide-stable-lakes toggle.

When the dashboard is embedded in an iframe on a cooperating parent site, the *parent page's own address bar* stays in sync too (via `history.replaceState`, no reload), so a link copied from there restores the parent page with the iframe in the same state. The dashboard's own copy-link button always copies the dashboard's own URL — it's the parent page (via `embed/water-timeseries-embed.js`) that's responsible for producing the parent-site link, not the embedded app.

The postMessage protocol (`mcui:state`) and the `params` naming follow the plan finalized in [metacatui#2841](https://github.com/NCEAS/metacatui/issues/2841), so this integrates cleanly once MetacatUI's side lands: no handshake, no app-side knowledge of the parent's URL — the app just posts a versioned state snapshot and lets the parent (embed.js today, MetacatUI later) own all URL construction.

**Changes**

- New `dashboard/share_state.py` — query-param schema (`selected_lake`, `lat`, `lon`, `zoom`, `drained`, `month`, `hide_stable`; defaults omitted), one-time restore-from-URL, live-view tracking, copy-link button, and a `postMessage({type: "mcui:state", ...})` bridge to parent pages.
- Two new embed-config query params, set once by an embedding parent and never echoed back: `theme=light|dark` (forces the color scheme via Streamlit's native `embed_options`) and `show_share=false` (hides the copy-link button, e.g. when the parent offers its own shareable link).
- `map_viewer.py` — captures live pan/zoom from `st_folium`; URL params stay in sync as the user interacts. Also fixes two pre-existing issues: the recenter-to-selection now fires once per selection instead of every rerun, and the "Hide stable lakes" toggle no longer reads a dead session key.
- New `embed/water-timeseries-embed.js` — drop-in snippet for parent sites (see guide below), documented in `docs/embedding.md`.
- Tests: `tests/test_share_state.py` (encode/decode units + `AppTest` restore checks), 17 passing.

**Notes**

- The viz configuration (`--viz-configuration`) stays deployment-fixed and out of the URL.
- Optionally set `WT_PARENT_ORIGIN=<parent origin>` on the dashboard host to restrict state messages to one parent site (default: any).

---

## Guide for parent-site maintainers

To embed the dashboard with working deep links, you need `water-timeseries-embed.js` (from the `embed/` directory of this repo) and three lines of setup:

```html
<iframe id="wt-frame" allow="clipboard-write"
        style="width: 100%; height: 90vh; border: 0;"></iframe>

<script src="water-timeseries-embed.js"></script>
<script>
  WaterTimeseriesEmbed.init({
    iframe: "#wt-frame",
    appUrl: "https://your-dashboard-host.example.org",
  });
</script>
