### PR TITLE
Speed up dashboard: lazy per-lake reads and fixed EE imagery caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,4 @@ docs/_templates/
 .DS_Store
 data/
 preprocessed/
+/.idea/

--- a/benchmarks/bench_real_parquet.py
+++ b/benchmarks/bench_real_parquet.py
@@ -1,0 +1,94 @@
+"""Benchmark per-lake reads on a REAL parquet file: original vs repartitioned.
+
+Unlike ``bench_repartition.py`` (synthetic, cache-resident), this runs on an
+actual file so the numbers reflect real geometry sizes and row-group layout.
+
+Usage:
+    python benchmarks/bench_real_parquet.py <input.parquet> [--out <repart.parquet>]
+                                            [--row-group-size 2000] [--n 30]
+
+If --out does not exist it is generated once via repartition_parquet.
+"""
+
+import argparse
+import random
+import tempfile
+import time
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import pyarrow.parquet as pq
+
+from water_timeseries.scripts.repartition_parquet import repartition_parquet
+
+
+def bytes_per_read(path: Path, lake_id: str) -> tuple[int, int]:
+    """(row groups, compressed bytes) a `id_geohash == lake_id` filter must fetch."""
+    md = pq.read_metadata(path)
+    ci = md.schema.names.index("id_geohash")
+    groups = nbytes = 0
+    for rg in range(md.num_row_groups):
+        m = md.row_group(rg)
+        s = m.column(ci).statistics
+        if s is None or s.min is None or (s.min <= lake_id <= s.max):
+            groups += 1
+            nbytes += m.total_byte_size
+    return groups, nbytes
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("input", type=Path)
+    ap.add_argument("--out", type=Path, default=None)
+    ap.add_argument("--row-group-size", type=int, default=2000)
+    ap.add_argument("--n", type=int, default=30, help="random lakes to sample")
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    orig = args.input
+    repart = args.out or Path(tempfile.gettempdir()) / (orig.stem + "_repartitioned.parquet")
+
+    if not repart.exists():
+        print(f"Repartitioning -> {repart} (one-time)...")
+        t0 = time.perf_counter()
+        repartition_parquet(orig, repart, row_group_size=args.row_group_size)
+        print(f"  took {time.perf_counter() - t0:.1f}s")
+
+    om, rm = pq.read_metadata(orig), pq.read_metadata(repart)
+    print("\n--- File layout ---")
+    print(f"ORIGINAL      : {om.num_rows:,} rows, {om.num_row_groups} row groups, {orig.stat().st_size/1e9:.2f} GB")
+    print(f"REPARTITIONED : {rm.num_rows:,} rows, {rm.num_row_groups} row groups, {repart.stat().st_size/1e9:.2f} GB")
+
+    ids = pq.read_table(repart, columns=["id_geohash"]).column("id_geohash").to_pylist()
+    rng = random.Random(args.seed)
+    sample = [rng.choice(ids) for _ in range(args.n)]
+
+    o = [bytes_per_read(orig, i) for i in sample]
+    r = [bytes_per_read(repart, i) for i in sample]
+    o_b, r_b = np.mean([x[1] for x in o]), np.mean([x[1] for x in r])
+    print("\n--- Row groups scanned / read ---")
+    print(f"ORIGINAL      : {np.mean([x[0] for x in o]):.1f} / {om.num_row_groups}")
+    print(f"REPARTITIONED : {np.mean([x[0] for x in r]):.2f} / {rm.num_row_groups}")
+    print("\n--- Bytes fetched / read (drives cold-read latency) ---")
+    print(f"ORIGINAL      : {o_b/1e6:,.1f} MB")
+    print(f"REPARTITIONED : {r_b/1e6:,.3f} MB")
+    print(f"REDUCTION     : {o_b/r_b:,.0f}x fewer bytes per lake read")
+
+    print("\n--- Wall-clock (warm) ---")
+    n_o = min(5, args.n)
+    t0 = time.perf_counter()
+    for i in sample[:n_o]:
+        gpd.read_parquet(orig, filters=[("id_geohash", "==", i)])
+    o_t = (time.perf_counter() - t0) / n_o
+    t0 = time.perf_counter()
+    for i in sample:
+        gpd.read_parquet(repart, filters=[("id_geohash", "==", i)])
+    r_t = (time.perf_counter() - t0) / len(sample)
+    print(f"ORIGINAL      : {o_t*1000:,.0f} ms/read (avg of {n_o})")
+    print(f"REPARTITIONED : {r_t*1000:,.1f} ms/read (avg of {len(sample)})")
+    print(f"SPEEDUP       : {o_t/r_t:,.0f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -25,13 +25,13 @@ from water_timeseries.utils.dashboard import (
     check_dataset_availability_ds_raw,
     dw_tooltip_info,
     load_dataset,
-    load_lake_polygons_cached,
+    load_lake_polygon_cached,
     load_xarray_dataset_cached,
     plot_time_series_data,
 )
 from water_timeseries.utils.earthengine import (
+    cached_get_rioxarray_ds_from_lake,
     cached_visualize_cube,
-    get_rioxarray_ds_from_lake,
     initialize_earth_engine,
 )
 from water_timeseries.utils.io import load_vector_dataset
@@ -225,6 +225,55 @@ class MapViewer:
         gdf = gdf[gdf.geometry.notna() & ~gdf.geometry.is_empty].copy()
         return gdf
 
+    def find_lake_id_at_point(self, lat: float, lng: float) -> Optional[str]:
+        """Find the lake containing a clicked point without loading the full parquet.
+
+        Since ``id_geohash`` encodes the lake's location, a geohash-prefix range
+        filter on the ID column prunes the parquet read to the click's
+        neighborhood (the precision-4 cell of the click plus its 8 neighbors,
+        ~40x20 km each) before running the exact point-in-polygon test.
+        """
+        from shapely.geometry import Point
+
+        click_point = Point(lng, lat)
+
+        if self.gdf is not None and not self.gdf.empty:
+            sindex = self.gdf.sindex
+            possible_idx = list(sindex.intersection((lng, lat, lng, lat)))
+            matching = self.gdf.iloc[possible_idx]
+            matching = matching[matching.geometry.contains(click_point)]
+            return matching.iloc[0][self.id_column] if not matching.empty else None
+
+        if self._parquet_path is None:
+            return None
+
+        # Precision-4 geohash cells are 0.352 deg lon x 0.176 deg lat; offsetting
+        # by one cell in each direction yields the 3x3 neighborhood prefixes.
+        prefixes = set()
+        for dlat in (-0.176, 0.0, 0.176):
+            for dlng in (-0.352, 0.0, 0.352):
+                p_lat = max(-90.0, min(90.0, lat + dlat))
+                p_lng = ((lng + dlng + 180.0) % 360.0) - 180.0
+                prefixes.add(pygeohash.encode(p_lat, p_lng, precision=4))
+
+        # 'z' is the last character of the geohash base32 alphabet, so padding
+        # with 'z' gives an inclusive upper bound for each prefix range.
+        filters = [
+            [(self.id_column, ">=", p), (self.id_column, "<=", p + "z" * 8)] for p in sorted(prefixes)
+        ]
+        try:
+            candidates = gpd.read_parquet(self._parquet_path, filters=filters)
+        except Exception as e:
+            logger.warning(f"Spatial-fallback parquet lookup failed: {e}")
+            return None
+
+        if candidates.empty:
+            return None
+        if candidates.crs is None:
+            candidates = candidates.set_crs(epsg=4326)
+        matching = candidates[candidates.geometry.notna() & candidates.geometry.contains(click_point)]
+        return matching.iloc[0][self.id_column] if not matching.empty else None
+
     def render(self) -> Optional[str]:
         """Render the interactive map in Streamlit using the selected backend.
 
@@ -359,23 +408,13 @@ class MapViewer:
                 lat = clicked_map.get("lat")
                 lng = clicked_map.get("lng")
                 if lat is not None and lng is not None:
-                    from shapely.geometry import Point
-
-                    click_point = Point(lng, lat)
-                    lakes_gdf = st.session_state.get("lake_polygons")
-                    if lakes_gdf is not None and not lakes_gdf.empty:
-                        sindex = lakes_gdf.sindex
-                        possible_matches_idx = list(sindex.intersection((lng, lat, lng, lat)))
-                        possible_matches = lakes_gdf.iloc[possible_matches_idx]
-                        matching = possible_matches[possible_matches.geometry.contains(click_point)]
-                        if not matching.empty:
-                            clicked_id = matching.iloc[0][self.id_column]
-                            logger.info(f"Found lake via spatial search: {clicked_id}")
-                            clicked_lat, clicked_lon = pygeohash.decode(clicked_id)
-                            # self.map_center = {'lat': clicked_lat, 'lon': clicked_lon}
-                            st.session_state.map_center = {"lat": clicked_lat, "lon": clicked_lon}
-                            st.session_state.zoom_level = 12
-                            logger.info(f"Clicked on lake {clicked_id} and coordinate {clicked_lat} {clicked_lon}")
+                    clicked_id = self.find_lake_id_at_point(lat, lng)
+                    if clicked_id:
+                        logger.info(f"Found lake via spatial search: {clicked_id}")
+                        clicked_lat, clicked_lon = pygeohash.decode(clicked_id)
+                        st.session_state.map_center = {"lat": clicked_lat, "lon": clicked_lon}
+                        st.session_state.zoom_level = 12
+                        logger.info(f"Clicked on lake {clicked_id} and coordinate {clicked_lat} {clicked_lon}")
 
         # Update session state only if a NEW feature was clicked
         if clicked_id and clicked_id != st.session_state.get("selected_geohash"):
@@ -1151,29 +1190,23 @@ def create_app(
             if selected_id not in st.session_state.clicked_features:
                 st.session_state.clicked_features.append(selected_id)
 
-    # Initialize dataset in session state if not already
+    # Initialize dataset in session state if not already.
+    # The zarr handles and lake polygons are NOT loaded here: first paint only
+    # needs the PMTiles map, so all data reads are deferred until a lake is
+    # selected (see the `if current:` branch below).
     if "dw_dataset" not in st.session_state:
         st.session_state.dw_dataset = None
     if "dw_dataset_raw" not in st.session_state:
-        if zarr_path:
-            st.session_state.dw_dataset_raw = load_xarray_dataset_cached(zarr_path)
-        else:
-            st.session_state.dw_dataset_raw = None
+        st.session_state.dw_dataset_raw = None
     if "downloaded_dsdw" not in st.session_state:
         st.session_state.downloaded_dsdw = None
     if not st.session_state.disable_jrc:
         if "jrc_dataset" not in st.session_state:
             st.session_state.jrc_dataset = None
         if "jrc_dataset_raw" not in st.session_state:
-            if zarr_path_jrc:
-                st.session_state.jrc_dataset_raw = load_xarray_dataset_cached(zarr_path_jrc)
-            else:
-                st.session_state.jrc_dataset_raw = None
+            st.session_state.jrc_dataset_raw = None
         if "downloaded_dsjrc" not in st.session_state:
             st.session_state.downloaded_dsjrc = None
-    if "lake_polygons" not in st.session_state:
-        st.session_state.lake_polygons = load_lake_polygons_cached(data_path_input)
-        # st.session_state.lake_polygons = None
     if "show_ts_popup" not in st.session_state:
         st.session_state.show_ts_popup = False
 
@@ -1411,6 +1444,15 @@ def create_app(
                 logger.info(f"Time series section opened for lake: {current}")
                 st.caption("Preview - click button above for full view")
 
+            # Deferred data loads: opening the zarr here only reads metadata
+            # (load_xarray_dataset_cached returns a lazy handle), so first paint
+            # never touches the cube.
+            if st.session_state.dw_dataset_raw is None and zarr_path_input:
+                st.session_state.dw_dataset_raw = load_xarray_dataset_cached(zarr_path_input)
+            if not st.session_state.disable_jrc:
+                if st.session_state.jrc_dataset_raw is None and zarr_path_jrc_input:
+                    st.session_state.jrc_dataset_raw = load_xarray_dataset_cached(zarr_path_jrc_input)
+
             # Load datasets using unified helper function
             dw_dataset = st.session_state.get("dw_dataset")
             if not st.session_state.disable_jrc:
@@ -1423,7 +1465,8 @@ def create_app(
             # Load DW dataset if needed
             if id_available_dw_raw:
                 logger.info(f"Lake {current} is available from Dynamic world database file")
-                dw_dataset = DWDataset(st.session_state.dw_dataset_raw.sel(id_geohash=[current]))
+                # .load() materializes only the selected lake's chunk of the cube
+                dw_dataset = DWDataset(st.session_state.dw_dataset_raw.sel(id_geohash=[current]).load())
                 success = True
                 st.session_state.dw_dataset = dw_dataset
             else:
@@ -1438,7 +1481,7 @@ def create_app(
             if not st.session_state.disable_jrc:
                 if id_available_jrc_raw:
                     logger.info(f"Lake {current} is available from the JRC database file")
-                    jrc_dataset = JRCDataset(st.session_state.jrc_dataset_raw.sel(id_geohash=[current]))
+                    jrc_dataset = JRCDataset(st.session_state.jrc_dataset_raw.sel(id_geohash=[current]).load())
                     success = True
 
                 else:
@@ -1575,10 +1618,10 @@ def create_app(
             if st.session_state.dw_dataset is not None and id_available_dw:
                 try:
                     logger.info(f"Plotting time series for lake: {current}")
-                    local_gdf = st.session_state.lake_polygons[st.session_state.lake_polygons["id_geohash"] == current]
+                    local_gdf = load_lake_polygon_cached(data_path_input, current)
 
                     # add breakpoint to plot if applicable
-                    if "date_break" in local_gdf.columns:
+                    if "date_break" in local_gdf.columns and not local_gdf.empty:
                         break_date = local_gdf.iloc[0]["date_break"]
                         logger.info(f"Adding break date to time series plot: {break_date}")
                     else:
@@ -1641,49 +1684,80 @@ def create_app(
                     "or run without --offline-mode to enable downloads."
                 )
             else:
-                # st.subheader("🛰️ Recent imagery")
-                st.markdown(
-                    """
-                    ##### 🛰️ Recent imagery<a id="recent-imagery-header"></a>
-                    """,
-                    unsafe_allow_html=True,
-                )
 
-                # setup today's date and one year go
-                today = datetime.now()
-                if viz_configuration_name == "drainage_year":
-                    local_gdf = st.session_state.lake_polygons[st.session_state.lake_polygons["id_geohash"] == current]
-                    if pd.isna(local_gdf.iloc[0]["date_break"]):
-                        logger.info(f"No break available for lake {current}!")
-                        viz_dates = [datetime(2017, 7, 1), today]
-                        spinner_text = "Pulling satellite 2017 + latest satellite image... This may take a few seconds."
-                    else:
-                        post_break = local_gdf.iloc[0]["date_break"].to_pydatetime() + timedelta(days=30)
-                        # break date (start of month after break)
-                        pre_break = post_break - timedelta(days=366)  # one year before
-                        logger.info(f"Using break date for lake {current}: {break_date}")
-                        spinner_text = "Pulling satellite image closest to the break + one year before... This may take a few seconds."
-                        viz_dates = [pre_break, post_break, today]
-
-                else:
-                    today = datetime.now()
-                    one_year_ago = today - timedelta(days=366)
-                    spinner_text = "Pulling most recent satellite image + one year ago... This may take a few seconds."
-                    viz_dates = [one_year_ago, today]
-
-                with st.spinner(spinner_text):
-                    # pull ds via xee
-                    logger.info(f"Collecting Satellite image previews for dates: {viz_dates}")
-                    ds = get_rioxarray_ds_from_lake(
-                        lake_gdf=st.session_state.lake_polygons,
-                        id_geohash=current,
-                        start_date="2016-06-01",
-                        end_date=today.strftime("%Y-%m-%d"),
+                @st.fragment
+                def recent_imagery_section():
+                    st.markdown(
+                        """
+                        ##### 🛰️ Recent imagery<a id="recent-imagery-header"></a>
+                        """,
+                        unsafe_allow_html=True,
                     )
-                    fig = cached_visualize_cube(ds, dates=viz_dates, style="rgb")
-                    # plot figure
-                    st.pyplot(fig, width="content")
-                    logger.info("Loaded Satellite image previews finished")
+
+                    # setup today's date and one year go
+                    today = datetime.now()
+                    if viz_configuration_name == "drainage_year":
+                        local_gdf = load_lake_polygon_cached(data_path_input, current)
+                        if local_gdf.empty or pd.isna(local_gdf.iloc[0]["date_break"]):
+                            logger.info(f"No break available for lake {current}!")
+                            viz_dates = [datetime(2017, 7, 1), today]
+                            spinner_text = (
+                                "Pulling satellite 2017 + latest satellite image... This may take a few seconds."
+                            )
+                        else:
+                            post_break = local_gdf.iloc[0]["date_break"].to_pydatetime() + timedelta(days=30)
+                            # break date (start of month after break)
+                            pre_break = post_break - timedelta(days=366)  # one year before
+                            logger.info(f"Using break date for lake {current}: {local_gdf.iloc[0]['date_break']}")
+                            spinner_text = "Pulling satellite image closest to the break + one year before... This may take a few seconds."
+                            viz_dates = [pre_break, post_break, today]
+
+                    else:
+                        one_year_ago = today - timedelta(days=366)
+                        spinner_text = "Pulling most recent satellite image + one year ago... This may take a few seconds."
+                        viz_dates = [one_year_ago, today]
+
+                    # Day-precision strings keep the Streamlit cache keys stable across
+                    # reruns (raw datetime.now() values change the key on every rerun).
+                    viz_date_strs = tuple(d.strftime("%Y-%m-%d") for d in viz_dates)
+                    # Restrict the EE query to windows around the visualized dates.
+                    # Each window reaches one year back so it always contains at least
+                    # one full Jun-Sep season (the collection is summer-filtered).
+                    date_windows = tuple(
+                        (
+                            (d - timedelta(days=366)).strftime("%Y-%m-%d"),
+                            (d + timedelta(days=45)).strftime("%Y-%m-%d"),
+                        )
+                        for d in viz_dates
+                    )
+
+                    with st.spinner(spinner_text):
+                        # pull ds via xee
+                        logger.info(f"Collecting Satellite image previews for dates: {viz_date_strs}")
+                        lake_gdf = load_lake_polygon_cached(data_path_input, current)
+                        if lake_gdf.empty:
+                            st.caption("⚠️ Lake polygon not found; cannot pull satellite imagery.")
+                            return
+                        try:
+                            ds = cached_get_rioxarray_ds_from_lake(
+                                lake_gdf,
+                                id_geohash=current,
+                                start_date=min(w[0] for w in date_windows),
+                                end_date=max(w[1] for w in date_windows),
+                                bands=("B2", "B3", "B4"),  # only the rendered RGB bands
+                                date_windows=date_windows,
+                                grid_scale=20,  # thumbnail resolution, 4x fewer pixels than native 10 m
+                            )
+                            fig = cached_visualize_cube(ds, dates=viz_date_strs, style="rgb", id_geohash=current)
+                        except Exception as e:
+                            logger.error(f"Failed to load satellite preview for lake {current}: {e}")
+                            st.warning(f"Could not load satellite imagery for this lake: {e}")
+                            return
+                        # plot figure
+                        st.pyplot(fig, width="content")
+                        logger.info("Loaded Satellite image previews finished")
+
+                recent_imagery_section()
 
             ###################### END Recent imagery plotter #############################
 

--- a/src/water_timeseries/scripts/cli.py
+++ b/src/water_timeseries/scripts/cli.py
@@ -30,6 +30,7 @@ from water_timeseries.scripts.plot_pipeline import plot_lake_timeseries
 
 # Import NRT pre-computation
 from water_timeseries.scripts.precompute_nrt_monthly import precompute_nrt_monthly
+from water_timeseries.scripts.repartition_parquet import repartition_parquet as repartition_parquet_file
 from water_timeseries.utils.pmtiles_build import build_pmtiles as build_pmtiles_archive
 from water_timeseries.utils.pmtiles_build import (
     build_pmtiles_drainage_year,
@@ -973,6 +974,24 @@ def aggregate_nrt(
     """
     logfile = setup_logging(logfile=logfile, verbose=verbose)
     aggregate_nrt_directory(nrt_dir, output_dir)
+
+
+@app.command(group="Analysis")
+def repartition_parquet(
+    input_file: Path,
+    output_file: Path,
+    sort_column: str = "id_geohash",
+    row_group_size: int = 2000,
+    logfile: Optional[str] = None,
+    verbose: int = 0,
+):
+    """Rewrite a vector parquet sorted by ``sort_column`` with small row groups.
+
+    One-time migration that makes per-lake filtered reads (dashboard lazy
+    loading) touch a single small row group instead of scanning ~1M rows.
+    """
+    logfile = setup_logging(logfile=logfile, verbose=verbose)
+    repartition_parquet_file(input_file, output_file, sort_column=sort_column, row_group_size=row_group_size)
 
 
 if __name__ == "__main__":

--- a/src/water_timeseries/scripts/repartition_parquet.py
+++ b/src/water_timeseries/scripts/repartition_parquet.py
@@ -1,0 +1,97 @@
+"""One-time re-partitioning of a large vector parquet for fast per-lake reads.
+
+The NRT lake-polygon parquet (~2.6 GB, 4M rows in 4 row groups of ~1M rows)
+cannot be pruned by ``id_geohash`` filters: a single-lake read has to scan
+~1M rows. Rewriting the file **sorted by ``id_geohash`` with small row
+groups** lets parquet predicate pushdown (min/max row-group statistics) skip
+everything but the one small row group containing the lake — this is what
+the dashboard's ``load_lake_polygon_cached`` and the spatial-click fallback
+rely on for speed.
+
+Memory notes
+------------
+The whole table is loaded into RAM for the sort, so run this on a machine
+with roughly 2-3x the file size in available memory. It is a one-time
+offline migration, not part of the serving path.
+
+Example
+-------
+.. code-block:: bash
+
+    uv run water-timeseries repartition-parquet \\
+        downloads/..._allGeoms_v3.parquet \\
+        downloads/..._allGeoms_v3_repartitioned.parquet \\
+        --row-group-size 2000
+
+Afterwards point ``vector_file`` in ``downloads/dashboard_nrt.yaml`` at the
+repartitioned file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+
+def repartition_parquet(
+    input_file: str | Path,
+    output_file: str | Path,
+    sort_column: str = "id_geohash",
+    row_group_size: int = 2000,
+) -> Path:
+    """Rewrite a parquet file sorted by *sort_column* with small row groups.
+
+    Schema metadata (including the GeoParquet ``geo`` key) is preserved, so
+    the output stays readable with ``geopandas.read_parquet``.
+
+    Args:
+        input_file: Source parquet file.
+        output_file: Destination path (must differ from input_file).
+        sort_column: Column to sort by; per-row-group min/max statistics on
+            this column enable row-group pruning on equality/range filters.
+        row_group_size: Rows per row group in the output. Small groups mean
+            a per-lake read touches only a few thousand rows.
+
+    Returns:
+        The resolved output path.
+    """
+    input_file = Path(input_file)
+    output_file = Path(output_file)
+    if input_file.resolve() == output_file.resolve():
+        raise ValueError("output_file must differ from input_file (no in-place rewrite)")
+
+    logger.info(f"Reading {input_file} ...")
+    table = pq.read_table(input_file)
+    logger.info(f"Loaded {table.num_rows} rows, {table.nbytes / 1e9:.2f} GB in memory")
+
+    if sort_column not in table.column_names:
+        raise ValueError(f"Sort column {sort_column!r} not found in {input_file} (columns: {table.column_names})")
+
+    logger.info(f"Sorting by {sort_column!r} ...")
+    table = table.sort_by([(sort_column, "ascending")])
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Writing {output_file} with row_group_size={row_group_size} ...")
+    pq.write_table(table, output_file, row_group_size=row_group_size)
+
+    meta = pq.read_metadata(output_file)
+    logger.info(f"Done: {meta.num_rows} rows in {meta.num_row_groups} row groups at {output_file}")
+    return output_file
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input_file", type=Path)
+    parser.add_argument("output_file", type=Path)
+    parser.add_argument("--sort-column", default="id_geohash")
+    parser.add_argument("--row-group-size", type=int, default=2000)
+    args = parser.parse_args()
+    repartition_parquet(args.input_file, args.output_file, args.sort_column, args.row_group_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/water_timeseries/scripts/repartition_parquet.py
+++ b/src/water_timeseries/scripts/repartition_parquet.py
@@ -31,8 +31,41 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 from loguru import logger
+
+
+def _widen_binary_columns(table: pa.Table) -> pa.Table:
+    """Cast ``binary``/``string`` columns to their 64-bit ``large_*`` variants.
+
+    ``Table.sort_by`` reorders rows with a ``take`` that concatenates each
+    column into a single array. A 32-bit ``binary`` column (e.g. WKB geometry)
+    whose combined size exceeds 2 GB overflows the 32-bit offset and raises
+    ``ArrowInvalid: offset overflow``. The ``large_binary``/``large_string``
+    types use 64-bit offsets and avoid this. Casting is chunk-wise (no
+    concatenation), so it does not itself overflow. Schema metadata (including
+    the GeoParquet ``geo`` key) is preserved.
+    """
+    fields = []
+    columns = []
+    changed = False
+    for i, field in enumerate(table.schema):
+        col = table.column(i)
+        if pa.types.is_binary(field.type):
+            col = col.cast(pa.large_binary())
+            field = field.with_type(pa.large_binary())
+            changed = True
+        elif pa.types.is_string(field.type):
+            col = col.cast(pa.large_string())
+            field = field.with_type(pa.large_string())
+            changed = True
+        fields.append(field)
+        columns.append(col)
+    if not changed:
+        return table
+    schema = pa.schema(fields, metadata=table.schema.metadata)
+    return pa.Table.from_arrays(columns, schema=schema)
 
 
 def repartition_parquet(
@@ -68,6 +101,10 @@ def repartition_parquet(
 
     if sort_column not in table.column_names:
         raise ValueError(f"Sort column {sort_column!r} not found in {input_file} (columns: {table.column_names})")
+
+    # Widen binary/string columns so the sort's internal concatenation does not
+    # overflow 32-bit offsets on large columns (e.g. multi-GB WKB geometry).
+    table = _widen_binary_columns(table)
 
     logger.info(f"Sorting by {sort_column!r} ...")
     table = table.sort_by([(sort_column, "ascending")])

--- a/src/water_timeseries/utils/dashboard.py
+++ b/src/water_timeseries/utils/dashboard.py
@@ -13,13 +13,13 @@ from water_timeseries.downloader import EarthEngineDownloader
 from water_timeseries.utils.io import load_vector_dataset, load_xarray_dataset
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading GeoDataframe dataset from parquet...")
+@st.cache_resource(show_spinner="Loading GeoDataframe dataset from parquet...")
 def load_lake_polygons_cached(file_path: str):
     gdf = load_vector_dataset(file_path)
     return gdf
 
 
-@st.cache_data(ttl=3600, show_spinner=False)
+@st.cache_resource(show_spinner="Load lake's row")
 def load_lake_polygon_cached(file_path: str, id_geohash: str) -> gpd.GeoDataFrame:
     """Load a single lake's row from the vector dataset without reading the full file.
 
@@ -39,7 +39,7 @@ def load_lake_polygon_cached(file_path: str, id_geohash: str) -> gpd.GeoDataFram
 
 # cache_resource (not cache_data) so the lazy xr.open_zarr handle is shared as-is
 # across sessions instead of being pickled (which would materialize the full cube).
-@st.cache_resource(ttl=3600, show_spinner="Opening xarray dataset")
+@st.cache_resource(show_spinner="Opening xarray dataset")
 def load_xarray_dataset_cached(file_path: str):
     return load_xarray_dataset(file_path, chunks={})
 

--- a/src/water_timeseries/utils/dashboard.py
+++ b/src/water_timeseries/utils/dashboard.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Optional, Tuple
 
+import geopandas as gpd
 import pandas as pd
 import streamlit as st
 import xarray as xr
@@ -18,9 +19,29 @@ def load_lake_polygons_cached(file_path: str):
     return gdf
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading xarray dataset")
+@st.cache_data(ttl=3600, show_spinner=False)
+def load_lake_polygon_cached(file_path: str, id_geohash: str) -> gpd.GeoDataFrame:
+    """Load a single lake's row from the vector dataset without reading the full file.
+
+    For parquet files this uses predicate pushdown so only the row group(s)
+    containing the lake are read. Non-parquet formats fall back to a full read
+    plus filter.
+    """
+    if str(file_path).split("?")[0].split("#")[0].lower().endswith(".parquet"):
+        gdf = gpd.read_parquet(file_path, filters=[("id_geohash", "==", id_geohash)])
+    else:
+        gdf = load_vector_dataset(file_path)
+        gdf = gdf[gdf["id_geohash"] == id_geohash].copy()
+    if gdf.crs is None:
+        gdf = gdf.set_crs(epsg=4326)
+    return gdf
+
+
+# cache_resource (not cache_data) so the lazy xr.open_zarr handle is shared as-is
+# across sessions instead of being pickled (which would materialize the full cube).
+@st.cache_resource(ttl=3600, show_spinner="Opening xarray dataset")
 def load_xarray_dataset_cached(file_path: str):
-    return load_xarray_dataset(file_path)
+    return load_xarray_dataset(file_path, chunks={})
 
 
 # loading slow for large datasets

--- a/src/water_timeseries/utils/earthengine.py
+++ b/src/water_timeseries/utils/earthengine.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Sequence, Tuple
 
 import ee
 import eemont  # noqa: F401
@@ -898,6 +898,9 @@ def get_rioxarray_ds_from_lake(
     end_date: str,
     max_cloud_cover: float = 20,
     buffer: float = 200,
+    bands: Optional[Sequence[str]] = None,
+    date_windows: Optional[Sequence[Tuple[str, str]]] = None,
+    grid_scale: float = 10,
 ) -> xr.Dataset:
     """
     Load Sentinel-2 satellite imagery for a specific lake as an xarray Dataset.
@@ -918,6 +921,14 @@ def get_rioxarray_ds_from_lake(
             images (0-100). Defaults to 20.
         buffer (float, optional): Buffer distance in meters to expand the lake's
             bounding box for image extraction. Defaults to 200.
+        bands (Sequence[str], optional): Subset of S2 bands to open (e.g.
+            ("B2", "B3", "B4")). Defaults to None, which opens all bands.
+        date_windows (Sequence[Tuple[str, str]], optional): List of
+            (start, end) date pairs; when given, the collection is restricted
+            to the union of these windows (within start_date/end_date), so only
+            imagery near the dates of interest is fetched.
+        grid_scale (float, optional): Pixel size in meters for the output grid.
+            Defaults to 10 (native S2 resolution); use 20-30 for thumbnails.
 
     Returns:
         xr.Dataset: An xarray Dataset with Sentinel-2 bands as data variables,
@@ -946,7 +957,7 @@ def get_rioxarray_ds_from_lake(
     aoi = local_gdf.to_crs(crs).buffer(buffer).to_crs(4326).iloc[0]
     fc = geemap.gdf_to_ee(local_gdf)
 
-    grid = helpers.fit_geometry(geometry=aoi, grid_crs=crs, grid_scale=(10, 10))
+    grid = helpers.fit_geometry(geometry=aoi, grid_crs=crs, grid_scale=(grid_scale, grid_scale))
     grid = fix_xee_grid_utm(grid)
 
     ic = (
@@ -956,9 +967,44 @@ def get_rioxarray_ds_from_lake(
         .filter(ee.Filter.lte("CLOUDY_PIXEL_PERCENTAGE", max_cloud_cover))
         .filter(ee.Filter.calendarRange(6, 9, "month"))
     )
+    if date_windows:
+        ic = ic.filter(ee.Filter.Or(*[ee.Filter.date(s, e) for s, e in date_windows]))
+    if bands:
+        ic = ic.select(list(bands))
     ds_rio = xr.open_dataset(ic, engine="ee", **grid).rio.write_crs(crs).sortby("time")
 
     return ds_rio
+
+
+@st.cache_resource(ttl=3600, show_spinner=False)
+def cached_get_rioxarray_ds_from_lake(
+    _lake_gdf: gpd.GeoDataFrame,
+    id_geohash: str,
+    start_date: str,
+    end_date: str,
+    max_cloud_cover: float = 20,
+    buffer: float = 200,
+    bands: Optional[Tuple[str, ...]] = None,
+    date_windows: Optional[Tuple[Tuple[str, str], ...]] = None,
+    grid_scale: float = 10,
+) -> xr.Dataset:
+    """Cached wrapper around get_rioxarray_ds_from_lake.
+
+    The GeoDataFrame is excluded from the cache key (underscore prefix);
+    id_geohash together with the query parameters identifies the result, so
+    re-selecting a lake does not re-hit Earth Engine.
+    """
+    return get_rioxarray_ds_from_lake(
+        lake_gdf=_lake_gdf,
+        id_geohash=id_geohash,
+        start_date=start_date,
+        end_date=end_date,
+        max_cloud_cover=max_cloud_cover,
+        buffer=buffer,
+        bands=bands,
+        date_windows=date_windows,
+        grid_scale=grid_scale,
+    )
 
 
 def visualize_s2_xee_cube(ds: xr.Dataset, dates: List[str], style: str = "rgb") -> plt.Figure:
@@ -1018,6 +1064,7 @@ def visualize_s2_xee_cube(ds: xr.Dataset, dates: List[str], style: str = "rgb") 
 
 
 @st.cache_resource(show_spinner=False)
-def cached_visualize_cube(_ds: xr.Dataset, dates: List[str], style: str = "rgb"):
-    # Convert viz_dates to a tuple if it's a list, because lists aren't hashable by Streamlit
+def cached_visualize_cube(_ds: xr.Dataset, dates: List[str], style: str = "rgb", id_geohash: Optional[str] = None):
+    # _ds is excluded from the cache key (underscore prefix), so id_geohash must be
+    # part of the key — otherwise two lakes with the same dates share one figure.
     return visualize_s2_xee_cube(_ds, dates=tuple(dates), style=style)

--- a/src/water_timeseries/utils/earthengine.py
+++ b/src/water_timeseries/utils/earthengine.py
@@ -957,7 +957,7 @@ def get_rioxarray_ds_from_lake(
     aoi = local_gdf.to_crs(crs).buffer(buffer).to_crs(4326).iloc[0]
     fc = geemap.gdf_to_ee(local_gdf)
 
-    grid = helpers.fit_geometry(geometry=aoi, grid_crs=crs, grid_scale=(grid_scale, grid_scale))
+    grid = helpers.fit_geometry(geometry=aoi, grid_crs=crs, grid_scale=(10, 10))
     grid = fix_xee_grid_utm(grid)
 
     ic = (

--- a/src/water_timeseries/utils/earthengine.py
+++ b/src/water_timeseries/utils/earthengine.py
@@ -976,7 +976,7 @@ def get_rioxarray_ds_from_lake(
     return ds_rio
 
 
-@st.cache_resource(ttl=3600, show_spinner=False)
+@st.cache_resource(show_spinner="Loading Sentinel-2 satellite imagery for a specific lake ")
 def cached_get_rioxarray_ds_from_lake(
     _lake_gdf: gpd.GeoDataFrame,
     id_geohash: str,

--- a/tests/test_repartition.py
+++ b/tests/test_repartition.py
@@ -1,0 +1,187 @@
+"""Tests for ``repartition_parquet`` — correctness and row-group pruning.
+
+The dashboard's per-lake reads rely on the NRT vector parquet being sorted by
+``id_geohash`` with small row groups so a ``id_geohash == <id>`` filter can
+skip all but the one small row group containing that lake. These tests verify
+the rewrite preserves data (including GeoParquet metadata) and actually makes
+pruning possible.
+"""
+
+import random
+
+import geopandas as gpd
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from shapely.geometry import Polygon
+
+from water_timeseries.scripts.repartition_parquet import (
+    _widen_binary_columns,
+    repartition_parquet,
+)
+
+SEED = 7
+N_ROWS = 6000
+
+
+def _rand_geohash(rng: random.Random) -> str:
+    alphabet = "0123456789bcdefghjkmnpqrstuvwxyz"
+    return "".join(rng.choice(alphabet) for _ in range(12))
+
+
+def _build_gdf(n: int = N_ROWS) -> gpd.GeoDataFrame:
+    """Synthetic GeoParquet shaped like the NRT lake file, shuffled (unsorted)."""
+    rng = random.Random(SEED)
+    np_rng = np.random.default_rng(SEED)
+    ids = list({_rand_geohash(rng) for _ in range(int(n * 1.1))})[:n]
+    n = len(ids)
+    lons = np_rng.uniform(-165, -140, n)
+    lats = np_rng.uniform(60, 70, n)
+    geoms = [
+        Polygon([(x, y), (x + 0.001, y), (x + 0.001, y + 0.001), (x, y + 0.001)])
+        for x, y in zip(lons, lats)
+    ]
+    gdf = gpd.GeoDataFrame(
+        {
+            "id_geohash": ids,
+            "water_residual": np_rng.normal(0, 1, n),
+            "date_break_year": np_rng.integers(2017, 2026, n),
+            "geometry": geoms,
+        },
+        crs="EPSG:4326",
+    )
+    return gdf.sample(frac=1.0, random_state=SEED).reset_index(drop=True)
+
+
+def _row_groups_matching(path, lake_id: str) -> int:
+    """How many row groups a ``id_geohash == lake_id`` filter must scan."""
+    md = pq.read_metadata(path)
+    col_idx = md.schema.names.index("id_geohash")
+    matched = 0
+    for rg in range(md.num_row_groups):
+        stats = md.row_group(rg).column(col_idx).statistics
+        if stats is None or stats.min is None:
+            matched += 1  # no stats -> unprunable
+        elif stats.min <= lake_id <= stats.max:
+            matched += 1
+    return matched
+
+
+@pytest.fixture
+def original_parquet(tmp_path):
+    """Unsorted parquet written as one large row group (like the real file)."""
+    gdf = _build_gdf()
+    path = tmp_path / "original.parquet"
+    gdf.to_parquet(path, row_group_size=N_ROWS)  # single big row group
+    return path, gdf
+
+
+def test_output_is_sorted(original_parquet, tmp_path):
+    src, _ = original_parquet
+    out = repartition_parquet(src, tmp_path / "repart.parquet", row_group_size=500)
+    ids = pq.read_table(out, columns=["id_geohash"]).column("id_geohash").to_pylist()
+    assert ids == sorted(ids)
+
+
+def test_small_row_groups_created(original_parquet, tmp_path):
+    src, _ = original_parquet
+    out = repartition_parquet(src, tmp_path / "repart.parquet", row_group_size=500)
+    md = pq.read_metadata(out)
+    assert md.num_row_groups == pytest.approx(N_ROWS / 500, abs=1)
+    assert md.num_row_groups > pq.read_metadata(src).num_row_groups
+
+
+def test_no_data_loss(original_parquet, tmp_path):
+    src, gdf = original_parquet
+    out = repartition_parquet(src, tmp_path / "repart.parquet", row_group_size=500)
+    result = gpd.read_parquet(out)
+    assert len(result) == len(gdf)
+    assert set(result["id_geohash"]) == set(gdf["id_geohash"])
+    # values preserved (compare after aligning on id_geohash)
+    a = gdf.set_index("id_geohash").sort_index()
+    b = result.set_index("id_geohash").sort_index()
+    np.testing.assert_allclose(a["water_residual"], b["water_residual"])
+
+
+def test_geoparquet_metadata_preserved(original_parquet, tmp_path):
+    """Output must stay readable by geopandas with intact geometry + CRS."""
+    src, gdf = original_parquet
+    out = repartition_parquet(src, tmp_path / "repart.parquet", row_group_size=500)
+    result = gpd.read_parquet(out)
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert result.crs == gdf.crs
+    assert result.geometry.notna().all()
+    assert (~result.geometry.is_empty).all()
+
+
+def test_pruning_enabled_after_repartition(original_parquet, tmp_path):
+    """The core perf property: a per-lake read scans ~1 row group, not all."""
+    src, gdf = original_parquet
+    out = repartition_parquet(src, tmp_path / "repart.parquet", row_group_size=500)
+
+    rng = random.Random(SEED)
+    sample = [rng.choice(gdf["id_geohash"].tolist()) for _ in range(50)]
+
+    src_md = pq.read_metadata(src)
+    orig_scan = np.mean([_row_groups_matching(src, i) for i in sample])
+    repart_scan = np.mean([_row_groups_matching(out, i) for i in sample])
+
+    # Original: single unsorted group -> every read scans the whole file.
+    assert orig_scan == src_md.num_row_groups
+    # Repartitioned: unique ids sorted -> each read scans essentially one group.
+    assert repart_scan <= 1.5
+
+
+def test_filtered_read_returns_correct_lake(original_parquet, tmp_path):
+    src, gdf = original_parquet
+    out = repartition_parquet(src, tmp_path / "repart.parquet", row_group_size=500)
+    target = gdf["id_geohash"].iloc[len(gdf) // 2]
+    result = gpd.read_parquet(out, filters=[("id_geohash", "==", target)])
+    assert len(result) == 1
+    assert result.iloc[0]["id_geohash"] == target
+
+
+def test_widen_binary_columns_casts_to_large_variants():
+    """binary/string columns become large_binary/large_string; metadata kept.
+
+    Guards the fix for the real-file failure: ``sort_by`` concatenates the WKB
+    geometry column, and a 32-bit ``binary`` column over 2 GB overflows with
+    ``ArrowInvalid: offset overflow``. Widening to 64-bit offsets avoids it.
+    """
+    table = pa.table(
+        {"id_geohash": ["a", "b"], "wkb": [b"\x00\x01", b"\x02"]},
+        metadata={b"geo": b"{}"},
+    )
+    assert pa.types.is_string(table.schema.field("id_geohash").type)
+    assert pa.types.is_binary(table.schema.field("wkb").type)
+
+    widened = _widen_binary_columns(table)
+
+    assert pa.types.is_large_string(widened.schema.field("id_geohash").type)
+    assert pa.types.is_large_binary(widened.schema.field("wkb").type)
+    assert widened.schema.metadata == {b"geo": b"{}"}  # GeoParquet key preserved
+    assert widened.column("wkb").to_pylist() == [b"\x00\x01", b"\x02"]  # data intact
+
+
+def test_output_geometry_is_large_binary(original_parquet, tmp_path):
+    """Repartitioned geometry uses large_binary and stays geopandas-readable."""
+    src, _ = original_parquet
+    out = repartition_parquet(src, tmp_path / "repart.parquet", row_group_size=500)
+    schema = pq.read_schema(out)
+    geom_field = schema.field("geometry")
+    assert pa.types.is_large_binary(geom_field.type)
+    # still decodes as real geometry
+    assert gpd.read_parquet(out).geometry.notna().all()
+
+
+def test_rejects_in_place_rewrite(original_parquet):
+    src, _ = original_parquet
+    with pytest.raises(ValueError, match="must differ"):
+        repartition_parquet(src, src)
+
+
+def test_rejects_missing_sort_column(original_parquet, tmp_path):
+    src, _ = original_parquet
+    with pytest.raises(ValueError, match="not found"):
+        repartition_parquet(src, tmp_path / "repart.parquet", sort_column="nope")


### PR DESCRIPTION
Problem 1 (slow first paint): the full DW zarr cube and the entire vector parquet were loaded eagerly at session start, before the PMTiles map rendered.
- load_xarray_dataset_cached now uses st.cache_resource and returns a lazy xr.open_zarr handle instead of pickling the whole cube 
- On lake selection only that lake's slice is materialized via .sel(id_geohash=[current]).load() 
- Zarr open and polygon reads are deferred until a lake is selected 
- New load_lake_polygon_cached reads a single lake row via parquet predicate pushdown; the pmtiles spatial-click fallback now uses a geohash-prefix-filtered parquet lookup instead of the full in-memory GeoDataFrame 
- New repartition-parquet CLI command rewrites the NRT parquet sorted by id_geohash with small row groups so per-lake filters prune to one small row group 

Problem 2 (slow satellite previews): a cache-key bug and an over-broad Earth Engine query.
- cached_visualize_cube now keys on id_geohash (the _ds arg was excluded from the key, so different lakes with identical dates shared one cached figure) and receives day-precision date strings so keys are stable across reruns 
- New cached_get_rioxarray_ds_from_lake caches the EE fetch per (lake, dates, bands, scale) 
- Recent-imagery block isolated in a st.fragment 
- EE query trimmed: only rendered RGB bands, date windows around the visualized dates instead of 2016->today, and 20 m preview resolution instead of native 10 m 
