### PR TITLE
Fix Dark Mode Colors

### DIFF
--- a/src/water_timeseries/map_utils.py
+++ b/src/water_timeseries/map_utils.py
@@ -62,6 +62,7 @@ class PMTilesMapLibreTooltipWithRounding(folium.elements.JSCSSMixin, branca.elem
     }
     .feature-row table td {
     padding: 4px 8px;
+    color: #222;
     }
     .feature-row table td:first-child {
     font-weight: 500;

--- a/src/water_timeseries/utils/visualization.py
+++ b/src/water_timeseries/utils/visualization.py
@@ -69,6 +69,7 @@ def get_legend_html_net_change() -> str:
             z-index: 9999;
             font-size: 12px;
             background-color: white;
+            color: #222;
             padding: 10px;
             border-radius: 5px;
             box-shadow: 0 0 15px rgba(0,0,0,0.2);
@@ -119,6 +120,7 @@ def get_legend_html_date_drainage_year() -> str:
             z-index: 9999;
             font-size: 12px;
             background-color: white;
+            color: #222;
             padding: 10px;
             border-radius: 5px;
             box-shadow: 0 0 15px rgba(0,0,0,0.2);
@@ -164,6 +166,7 @@ def get_legend_html_nrt_drainage() -> str:
             z-index: 9999;
             font-size: 12px;
             background-color: white;
+            color: #222;
             padding: 10px;
             border-radius: 5px;
             box-shadow: 0 0 15px rgba(0,0,0,0.2);


### PR DESCRIPTION
Changed the text color to black for 
1. Map Legend
2. Hover
for both historical and nrt visualizations.
before:
<img width="2294" height="1274" alt="image" src="https://github.com/user-attachments/assets/abbf2bc9-2a13-4e30-ae72-7e828376ea77" />
after:
<img width="651" height="424" alt="Screenshot 2026-07-24 at 11 47 32 AM" src="https://github.com/user-attachments/assets/b86fd500-f964-4815-9430-41dde2af697c" />
