### PR TITLE
Narrow broad exception handlers with well-defined failure surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,9 +115,9 @@ exclude = [".venv", "build", "dist", "__pycache__"]
 
 [tool.ruff.lint]
 extend-select = ["I"]
-# BLE001: broad except clauses are deliberate resilience in the dashboard/pipeline code.
+# BLE001 is enforced: deliberate broad catches carry a per-line noqa instead.
 # S110/S112: the silent handlers guard optional cleanup where logging adds noise.
-extend-ignore = ["E203", "BLE001", "S110", "S112"]
+extend-ignore = ["E203", "S110", "S112"]
 
 [tool.pytest.ini_options]
 # Pytest configuration for water-timeseries

--- a/src/water_timeseries/breakpoint.py
+++ b/src/water_timeseries/breakpoint.py
@@ -233,7 +233,7 @@ class SimpleBreakpoint(BreakpointMethod):
                 if pos > 0:
                     previous_date = df.index[pos - 1]
                     after_date = df.index[pos + 1] if pos + 1 < len(df) else None
-            except Exception:
+            except (KeyError, IndexError, TypeError, ValueError):
                 previous_date = None
                 after_date = None
 

--- a/src/water_timeseries/dashboard/app.py
+++ b/src/water_timeseries/dashboard/app.py
@@ -43,7 +43,7 @@ def setup_logging(logfile: str | None = None, verbose: int = 0):
                 subcommand = sys.argv[1].replace("-", "_")
                 timestamp = datetime.now().astimezone().strftime("%Y%m%d_%H%M%S")
                 logfile = f"{subcommand}_{timestamp}.log"
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     # Add console output with nice formatting

--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -63,11 +63,11 @@ def _init_ee() -> None:
                 project = _ee_project or st.secrets.get("EE_PROJECT")
                 initialize_earth_engine(project=project)
                 return
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
         print("setting up EE with credentials file")
         initialize_earth_engine(project=_ee_project)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         print(f"Earth Engine initialization failed: {exc}")
 
 
@@ -262,7 +262,7 @@ class MapViewer:
         ]
         try:
             candidates = gpd.read_parquet(self._parquet_path, filters=filters)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning(f"Spatial-fallback parquet lookup failed: {e}")
             return None
 
@@ -965,7 +965,7 @@ def _load_precomputed_nrt(
                 counts_df = breaks_df.groupby("analysis_month").size().reset_index(name="drained_lake_count")
 
             return counts_df, breaks_df
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.error(f"Failed to load single pre-computed breaks file: {e}")
             return None, None
 
@@ -1006,11 +1006,11 @@ def _load_precomputed_nrt(
                             df = pd.read_parquet(file_path)
                             if not df.empty:
                                 dfs.append(df)
-                        except Exception as e:
+                        except (OSError, ValueError) as e:
                             logger.warning(f"Failed to read {file_path}: {e}")
                     if dfs:
                         breaks_df = pd.concat(dfs, ignore_index=True)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.error(f"Failed to load pre-computed NRT from remote directory {path_str}: {e}")
     else:
         nrt_dir = Path(precomputed_nrt_dir)
@@ -1033,7 +1033,7 @@ def _load_precomputed_nrt(
                         df = pd.read_parquet(file_path)
                         if not df.empty:
                             dfs.append(df)
-                    except Exception as e:
+                    except (OSError, ValueError) as e:
                         logger.warning(f"Failed to read {file_path}: {e}")
                 if dfs:
                     breaks_df = pd.concat(dfs, ignore_index=True)
@@ -1369,7 +1369,7 @@ def create_app(
                 selected = viewer.render()
 
                 return viewer, selected
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 st.error(f"Error loading data: {e!s}")
                 return None, None
 
@@ -1539,7 +1539,7 @@ def create_app(
                                     st.session_state.dw_dataset = st.session_state.dw_dataset.merge(
                                         downloaded_dataset_dw, how="id_geohash"
                                     )
-                                except Exception as merge_e:
+                                except Exception as merge_e:  # noqa: BLE001
                                     # If merge fails, use downloaded data only
                                     logger.warning(f"Could not merge DW data for lake {current}: {merge_e}")
                                     st.sidebar.warning(f"Could not merge data: {merge_e}")
@@ -1574,7 +1574,7 @@ def create_app(
                                     st.session_state.jrc_dataset = st.session_state.jrc_dataset.merge(
                                         downloaded_dataset_jrc, how="id_geohash"
                                     )
-                                except Exception as merge_e:
+                                except Exception as merge_e:  # noqa: BLE001
                                     # If merge fails, use downloaded data only
                                     logger.warning(f"Could not merge JRC data for lake {current}: {merge_e}")
                                     st.sidebar.warning(f"Could not merge data: {merge_e}")
@@ -1593,7 +1593,7 @@ def create_app(
                             st.rerun()
                         else:
                             st.error("Download returned no data.")
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     logger.error(f"Failed to download data for lake {current}: {e}")
                     st.error(f"Error downloading data: {e}")
                     st.info("Make sure you have Google Earth Engine authentication configured.")
@@ -1664,7 +1664,7 @@ def create_app(
                             with ts_col2:
                                 logger.info(f"JRC data not available for lake: {current}")
                                 st.caption("JRC data not available for this feature")
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     logger.error(f"Error plotting time series for lake {current}: {e}")
                     st.error(f"Error plotting time series: {e}")
 
@@ -1745,7 +1745,7 @@ def create_app(
                                 grid_scale=20,  # thumbnail resolution, 4x fewer pixels than native 10 m
                             )
                             fig = cached_visualize_cube(ds, dates=viz_date_strs, style="rgb", id_geohash=current)
-                        except Exception as e:
+                        except Exception as e:  # noqa: BLE001
                             logger.error(f"Failed to load satellite preview for lake {current}: {e}")
                             st.warning(f"Could not load satellite imagery for this lake: {e}")
                             return
@@ -1757,7 +1757,7 @@ def create_app(
 
             ###################### END Recent imagery plotter #############################
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         st.error(f"Error loading data: {e!s}")
         st.info("Please check the file path and ensure the parquet file exists.")
 

--- a/src/water_timeseries/dashboard/pmtiles_viewer.py
+++ b/src/water_timeseries/dashboard/pmtiles_viewer.py
@@ -103,7 +103,7 @@ def _build_map_config(
                 center = header["center"]
             if zoom is None:
                 zoom = float(header["zoom"])
-        except Exception as e:
+        except (OSError, ValueError) as e:
             print(f"Could not fetch remote PMTiles header: {e}")
             # Fall back to hardcoded Alaska defaults
     elif bounds is None and vector_file_for_bounds is not None:

--- a/src/water_timeseries/dashboard/tutorial_popup.py
+++ b/src/water_timeseries/dashboard/tutorial_popup.py
@@ -52,7 +52,7 @@ _CLOSE_BUTTON_HTML = """
             const url = window.parent.performance
                 .getEntriesByType("resource")
                 .map((e) => e.name)
-                .find((n) => /source-?sans/i.test(n) && !/italic/i.test(n) && /\.woff2?($|\?)/i.test(n));
+                .find((n) => /source-?sans/i.test(n) && !/italic/i.test(n) && /\\.woff2?($|\\?)/i.test(n));
             if (!url) return;
             const font = new FontFace("Source Sans", 'url("' + url + '")', { weight: "100 900" });
             font.load().then(() => document.fonts.add(font));

--- a/src/water_timeseries/downloader.py
+++ b/src/water_timeseries/downloader.py
@@ -171,7 +171,7 @@ class EarthEngineDownloader:
             self.ee_is_initialized = ee.data is not None and hasattr(ee.data, "getInfo")
             if not self.ee_is_initialized:
                 self._log_warning("Earth Engine may not be properly initialized")
-        except Exception:
+        except AttributeError:
             self.ee_is_initialized = False
             self._log_warning("Earth Engine initialization check failed")
         return self.ee_is_initialized
@@ -340,7 +340,7 @@ class EarthEngineDownloader:
                 # Create masks for land cover classes
                 im_classes = create_dw_classes_mask(ee.Image(im))
                 imlist.append(im_classes)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 # Skip dates with errors
                 continue
 

--- a/src/water_timeseries/scripts/break_pipeline.py
+++ b/src/water_timeseries/scripts/break_pipeline.py
@@ -35,7 +35,7 @@ def load_config(config_path: Path | None) -> dict:
                 return yaml.safe_load(f) or {}
             elif config_path.suffix == ".json":
                 return json.load(f)
-    except Exception as e:
+    except (OSError, ValueError, yaml.YAMLError) as e:
         if logger:
             logger.warning(f"Failed to load config file {config_path}: {e}")
     return {}

--- a/src/water_timeseries/scripts/cli.py
+++ b/src/water_timeseries/scripts/cli.py
@@ -71,7 +71,7 @@ def setup_logging(logfile: str | None = None, verbose: int = 0):
                 timestamp = datetime.now().astimezone().strftime("%Y%m%d_%H%M%S")
                 logfile = f"{subcommand}_{timestamp}.log"
                 print(f"Using default logfile: {logfile}")  # Use print to avoid circular logging
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
         # If no logfile set, log to console only
         if logfile is None:
@@ -888,7 +888,7 @@ def breakpoint_analysis_nrt(
                 **shared_kwargs,
             )
             total_drained += len(breaks_df)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.warning(f"Failed for {month_str}: {exc}")
             failed += 1
 
@@ -926,7 +926,7 @@ def aggregate_nrt_directory(nrt_dir: Path, output_dir: Path | None = None) -> No
         try:
             df = pd.read_parquet(file_path)
             dfs.append(df)
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.warning(f"Failed to read {file_path}: {e}")
 
     if not dfs:

--- a/src/water_timeseries/scripts/precompute_nrt_monthly.py
+++ b/src/water_timeseries/scripts/precompute_nrt_monthly.py
@@ -143,7 +143,7 @@ def _run_nrt_for_month(
                 )
                 if result is not None and not result.empty:
                     chunk_results.append(result)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "%s chunk [%d:%d] failed: %s",
                     month_ts.strftime("%Y-%m"),

--- a/src/water_timeseries/utils/cli.py
+++ b/src/water_timeseries/utils/cli.py
@@ -23,7 +23,7 @@ def load_config(config_path: Path | None, logger) -> dict:
                 return yaml.safe_load(f) or {}
             elif config_path.suffix == ".json":
                 return json.load(f)
-    except Exception as e:
+    except (OSError, ValueError, yaml.YAMLError) as e:
         logger.warning(f"Failed to load config file {config_path}: {e}")
     return {}
 

--- a/src/water_timeseries/utils/dashboard.py
+++ b/src/water_timeseries/utils/dashboard.py
@@ -70,7 +70,7 @@ def load_dataset(
     if downloaded_data is not None:
         try:
             return dataset_class(downloaded_data), True
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             st.error(f"Error processing downloaded {dataset_type.upper()} data: {e}")
             return None, False
 
@@ -82,7 +82,7 @@ def load_dataset(
     try:
         ds = load_xarray_dataset(str(zarr_path))
         return dataset_class(ds), True
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         st.error(f"Error loading {dataset_type.upper()} time series data: {e}")
         return None, False
 
@@ -164,7 +164,7 @@ def plot_time_series_data(
 
         return True
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         st.error(f"Error plotting {dataset_type.upper()} time series: {e}")
         return False
     return id_geohash in dataset.object_ids_
@@ -244,7 +244,7 @@ def download_dataset_if_needed(
                     merged_dataset = dataset_obj.merge(new_dataset, how="id_geohash")
                     st.session_state[f"downloaded_ds{dataset_type}"] = new_data
                     return new_data, merged_dataset, True
-                except Exception as merge_e:
+                except Exception as merge_e:  # noqa: BLE001
                     st.sidebar.warning(f"Could not merge {dataset_type.upper()} data: {merge_e}")
 
             st.session_state[f"downloaded_ds{dataset_type}"] = new_data
@@ -252,7 +252,7 @@ def download_dataset_if_needed(
 
         return downloaded_data, dataset_obj, False
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         st.error(f"Error downloading {dataset_type.upper()} data: {e}")
         return downloaded_data, dataset_obj, False
 
@@ -303,7 +303,7 @@ def create_timelapse_handler(
             overwrite_exists=False,
         )
         return Path(gif_path) if gif_path else None
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         st.error(f"Error creating {source.upper()} timelapse: {e}")
         return None
 

--- a/src/water_timeseries/utils/earthengine.py
+++ b/src/water_timeseries/utils/earthengine.py
@@ -177,7 +177,7 @@ def calc_monthly_dw(
             warnings.warn(f"No data available for start_date: {start_date.getInfo()}")
             return None
         raise
-    except Exception:
+    except Exception:  # noqa: BLE001
         warnings.warn(f"No data available for start_date: {start_date.getInfo()}")
         return None
 


### PR DESCRIPTION
- Config loaders catch (OSError, ValueError, yaml.YAMLError)
- local parquet-read loops catch (OSError, ValueError), which covers pyarrow's ArrowInvalid/ArrowIOError
- the pandas index lookup in get_first_break_date catches its lookup failure modes
- the EE initialization check catches AttributeError
- the remote PMTiles header fetch catches urllib's OSError family plus ValueError for malformed headers.