### PR TITLE
Update Docker Compose to use config.yaml files

### DIFF
--- a/configs/dashboard_historical.yaml
+++ b/configs/dashboard_historical.yaml
@@ -1,0 +1,20 @@
+# CONFIG File for PMTILES config - historical breakpoint across the arctic
+# Default config for docker compose; matches the production historical config.
+
+ee_project: pdg-project-406720
+
+vector_file: data/DW_historicalbp_simple_merged_breaks_with_allgeoms_v4.parquet
+pmtiles_file: data/DW_historicalbp_simple_merged_breaks_with_allgeoms_v4.pmtiles
+
+dw_dataset_file: data/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.nc
+# or from here gs://pdg-storage-default/workflows_optimization/lake_change_detection/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.zarr
+
+precomputed_nrt_dir: data/DW_historicalbp_simple_merged_breaks_nogeoms_v4
+
+dw_start_year: 2017
+dw_end_year: 2026
+dw_start_month: 6
+dw_end_month: 9
+
+viz_configuration: drainage_year
+logfile: logs/dashboard_historical_panarctic.log

--- a/configs/dashboard_historical.yaml
+++ b/configs/dashboard_historical.yaml
@@ -6,8 +6,9 @@ ee_project: pdg-project-406720
 vector_file: data/DW_historicalbp_simple_merged_breaks_with_allgeoms_v4.parquet
 pmtiles_file: data/DW_historicalbp_simple_merged_breaks_with_allgeoms_v4.pmtiles
 
-dw_dataset_file: data/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.nc
-# or from here gs://pdg-storage-default/workflows_optimization/lake_change_detection/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.zarr
+# Zarr copy of the dataset production reads as .nc; both come from
+# gs://pdg-storage-default/workflows_optimization/lake_change_detection/
+dw_dataset_file: data/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.zarr
 
 precomputed_nrt_dir: data/DW_historicalbp_simple_merged_breaks_nogeoms_v4
 

--- a/configs/dashboard_nrt.yaml
+++ b/configs/dashboard_nrt.yaml
@@ -6,7 +6,9 @@ ee_project: pdg-project-406720
 vector_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_subset.parquet
 pmtiles_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_subset.pmtiles
 
-dw_dataset_file: data/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.nc
+# Zarr copy of the dataset production reads as .nc; both come from
+# gs://pdg-storage-default/workflows_optimization/lake_change_detection/
+dw_dataset_file: data/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.zarr
 
 precomputed_nrt_dir: data/DW_historicalbp_simple_merged_breaks_nogeoms_v4
 

--- a/configs/dashboard_nrt.yaml
+++ b/configs/dashboard_nrt.yaml
@@ -1,10 +1,15 @@
-# CONFIG File for PMTILES config - near-real-time lake drainage
-# Matches the production NRT config; use via DASHBOARD_CONFIG=configs/dashboard_nrt.yaml.
+# CONFIG File for PMTILES config - near-real-time lake drainage, pan-arctic
+# Use via DASHBOARD_CONFIG=configs/dashboard_nrt.yaml.
 
 ee_project: pdg-project-406720
 
-vector_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_subset.parquet
-pmtiles_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_subset.pmtiles
+# Repartitioned copy (sorted by id_geohash, small row groups) for fast per-lake reads.
+# Generate it with:
+#   uv run water-timeseries repartition-parquet \
+#     data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_v3.parquet \
+#     data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_v3_repartitioned.parquet
+vector_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_v3_repartitioned.parquet
+pmtiles_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_v3.pmtiles
 
 # Zarr copy of the dataset production reads as .nc; both come from
 # gs://pdg-storage-default/workflows_optimization/lake_change_detection/
@@ -18,4 +23,4 @@ dw_start_month: 6
 dw_end_month: 9
 
 viz_configuration: nrt_drainage
-logfile: logs/dashboard_nrt_subset.log
+logfile: logs/dashboard_nrt_panarctic.log

--- a/configs/dashboard_nrt.yaml
+++ b/configs/dashboard_nrt.yaml
@@ -1,0 +1,19 @@
+# CONFIG File for PMTILES config - near-real-time lake drainage
+# Matches the production NRT config; use via DASHBOARD_CONFIG=configs/dashboard_nrt.yaml.
+
+ee_project: pdg-project-406720
+
+vector_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_subset.parquet
+pmtiles_file: data/DW_NRT/DW_NRT_2026-06_run2025-06-25/DW_NRT_2026-06_run2025-06-25_allGeoms_subset.pmtiles
+
+dw_dataset_file: data/lakes_dw_V2d_2016-2026-06_gapfilled_chunked.nc
+
+precomputed_nrt_dir: data/DW_historicalbp_simple_merged_breaks_nogeoms_v4
+
+dw_start_year: 2017
+dw_end_year: 2026
+dw_start_month: 6
+dw_end_month: 9
+
+viz_configuration: nrt_drainage
+logfile: logs/dashboard_nrt_subset.log

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,33 +3,22 @@ services:
     build: .
     image: water-timeseries-streamlit:latest
     working_dir: /app
+    # Use the installed CLI (same launch path as production/helm). All data
+    # paths live in the config file; point DASHBOARD_CONFIG at another YAML
+    # (e.g. configs/dashboard_nrt.yaml) to switch datasets.
     command:
-      - streamlit
-      - run
-      - src/water_timeseries/dashboard/app.py
-      - --server.port=8501
-      - --server.address=0.0.0.0
-      - --
-      - --vector-file
-      - ${VECTOR_FILE:-downloads/lake_polygons.parquet}
-      - --dw-dataset-file
-      - ${DW_DATASET_FILE:-downloads/data.zarr}
-      - --jrc-dataset-file
-      - ${JRC_DATASET_FILE:-downloads/lakes_jrc_viz.zarr}
-      - --precomputed-nrt-dir
-      - ${PRECOMPUTED_NRT_DIR:-downloads/nrt}
-      - --pmtiles-file
-      - ${PMTILES_FILE:-downloads/tiles/lake_polygons.pmtiles}
-      - --pmtiles-url
-      - ${PMTILES_URL:-}
-      - --viz-configuration
-      - ${VIZ_CONFIGURATION:-colored_historical}
+      - water-timeseries
+      - dashboard
+      - --config-file
+      - ${DASHBOARD_CONFIG:-configs/dashboard_historical.yaml}
     volumes:
       - .:/app
       # Keep image .venv; a plain .:/app mount would hide it with an empty host dir
       - /app/.venv
       # Large/local datasets (gitignored downloads/; override host dirs via .env)
       - ${DOWNLOADS_DIR:-./downloads}:/app/downloads:ro
+      # Datasets referenced by configs/dashboard_*.yaml (data/... paths, as in production)
+      - ${DATA_DIR:-./data}:/app/data:ro
       # Optional: host EE credentials (alternative to EARTHENGINE_TOKEN in .env)
       - ${EARTHENGINE_CREDENTIALS_DIR:-${HOME}/.config/earthengine}:/root/.config/earthengine:ro
       # Host GCloud Application Default Credentials (ADC)

--- a/src/water_timeseries/scripts/cli.py
+++ b/src/water_timeseries/scripts/cli.py
@@ -17,19 +17,11 @@ import pandas as pd
 import yaml
 from loguru import logger
 
-# Import pipeline and utilities from break_pipeline
-from water_timeseries.scripts.break_pipeline import (
-    BreakpointPipeline,
-    load_config,
-    merge_config_with_args,
-)
-
-# Import plotting function from plot_pipeline
-from water_timeseries.scripts.plot_pipeline import plot_lake_timeseries
-
-# Import NRT pre-computation
-from water_timeseries.scripts.precompute_nrt_monthly import precompute_nrt_monthly
+# Analysis modules (break_pipeline, plot_pipeline, precompute_nrt_monthly) are
+# imported lazily inside their subcommands: they pull in Rbeast's C extension,
+# which is unavailable on some platforms, and must not block e.g. `dashboard`.
 from water_timeseries.scripts.repartition_parquet import repartition_parquet as repartition_parquet_file
+from water_timeseries.utils.cli import load_config, merge_config_with_args
 from water_timeseries.utils.pmtiles_build import build_pmtiles as build_pmtiles_archive
 from water_timeseries.utils.pmtiles_build import (
     build_pmtiles_drainage_year,
@@ -143,7 +135,7 @@ viz_configuration: The visualization configuration name for the map viewer.
         water-timeseries dashboard --config-file configs/dashboard_config.yaml
     """
     # Load config file if provided"
-    config_dict = load_config(config_file) if config_file else {}
+    config_dict = load_config(config_file, logger) if config_file else {}
 
     # Debug: Log loaded config
     logger.debug(f"Loaded config from {config_file}: {config_dict}")
@@ -273,7 +265,7 @@ def build_pmtiles(
         water-timeseries dashboard --pmtiles-file tiles/lakes.pmtiles --vector-file lakes.parquet
     """
     # Load config file if provided
-    config_dict = load_config(config_file) if config_file else {}
+    config_dict = load_config(config_file, logger) if config_file else {}
 
     # Merge config with CLI args
     config_dict = merge_config_with_args(
@@ -491,7 +483,7 @@ def breakpoint_analysis_historical(
             --bbox-west 100 --bbox-south 20 --bbox-east 110 --bbox-north 30
     """
     # Load config file if provided
-    config_dict = load_config(config_file) if config_file else {}
+    config_dict = load_config(config_file, logger) if config_file else {}
 
     # Merge config with CLI args (CLI takes priority)
     config_dict = merge_config_with_args(
@@ -531,6 +523,8 @@ def breakpoint_analysis_historical(
     logfile = setup_logging(logfile=logfile_val, verbose=verbose_val)
 
     # Run the pipeline
+    from water_timeseries.scripts.break_pipeline import BreakpointPipeline
+
     pipeline = BreakpointPipeline(
         water_dataset_file=water_dataset_file,
         output_file=output_file,
@@ -604,7 +598,7 @@ def plot_timeseries(
         water-timeseries plot-timeseries --config-file configs/plot_config.yaml
     """
     # Load config file if provided
-    config_dict = load_config(config_file) if config_file else {}
+    config_dict = load_config(config_file, logger) if config_file else {}
 
     # Merge config with CLI args (CLI takes priority)
     # Note: show is handled separately since it's a bool
@@ -644,7 +638,8 @@ def plot_timeseries(
         f"show={show}"
     )
 
-    # Use the imported function
+    from water_timeseries.scripts.plot_pipeline import plot_lake_timeseries
+
     plot_lake_timeseries(
         water_dataset_file=water_dataset_file,
         lake_id=lake_id,
@@ -759,6 +754,8 @@ def breakpoint_analysis_nrt(
             --output-dir precomputed/nrt \\
             --no-resume
     """
+    from water_timeseries.scripts.precompute_nrt_monthly import precompute_nrt_monthly
+
     logfile = setup_logging(logfile=logfile, verbose=verbose)
 
     # --- Validate mode selection -------------------------------------------

--- a/src/water_timeseries/scripts/repartition_parquet.py
+++ b/src/water_timeseries/scripts/repartition_parquet.py
@@ -19,11 +19,11 @@ Example
 .. code-block:: bash
 
     uv run water-timeseries repartition-parquet \\
-        downloads/..._allGeoms_v3.parquet \\
-        downloads/..._allGeoms_v3_repartitioned.parquet \\
+        data/DW_NRT/.../..._allGeoms_v3.parquet \\
+        data/DW_NRT/.../..._allGeoms_v3_repartitioned.parquet \\
         --row-group-size 2000
 
-Afterwards point ``vector_file`` in ``downloads/dashboard_nrt.yaml`` at the
+Afterwards point ``vector_file`` in ``configs/dashboard_nrt.yaml`` at the
 repartitioned file.
 """
 


### PR DESCRIPTION
Closes #196

docker compose was launching streamlit directly instead of using the installed
package. Now it runs `water-timeseries dashboard --config-file ...`, same as
the helm deployment does in production.

Changes:
- compose command is now the CLI with a config file. Default is
  `configs/dashboard_historical.yaml`, switch datasets by setting
  `DASHBOARD_CONFIG` in .env (e.g. to `configs/dashboard_nrt.yaml`)
- dropped the per-file env vars (VECTOR_FILE etc.) - they can't be combined
  with a config file because unset vars pass empty strings that clobber the
  config values
- added tracked configs for historical and NRT that mirror the production
  ones. NRT is pan-arctic (repartitioned allGeoms_v3). Both point at the zarr
  DW dataset instead of the 13GB .nc since it's the same data
- new `data/` mount (override with DATA_DIR) laid out like production, so the
  same config paths work in both
- made the CLI import Rbeast-dependent modules lazily - the Rbeast wheel is
  broken in arm64 containers and was crashing every CLI command, including
  `dashboard` which doesn't even use it

Tested locally on Apple Silicon: both historical and NRT dashboards run in
docker and render the full datasets.