### PR TITLE
Fix issues with tiles position not in sync with basemap

### DIFF
--- a/src/water_timeseries/map_utils.py
+++ b/src/water_timeseries/map_utils.py
@@ -1,5 +1,6 @@
 import functools
 from pathlib import Path
+from typing import ClassVar
 
 import branca.element
 import folium
@@ -80,7 +81,7 @@ class PMTilesMapLibreLayerSynced(PMTilesMapLibreLayer):
             """
     )
 
-    default_js = [
+    default_js: ClassVar = [
         ("pmtiles", "https://unpkg.com/pmtiles@2.5.0/dist/index.js"),
         ("maplibre-lib", "https://unpkg.com/maplibre-gl@2.2.1/dist/maplibre-gl.js"),
         (

--- a/src/water_timeseries/map_utils.py
+++ b/src/water_timeseries/map_utils.py
@@ -28,10 +28,17 @@ class PMTilesMapLibreLayerSynced(PMTilesMapLibreLayer):
     maplibre-gl-leaflet only syncs the GL canvas on throttled Leaflet ``move``
     events, so the final update of a drag (especially a fast one, or during
     inertia) can be lost and the polygons stay offset from the basemap until
-    the next interaction. Registering an unthrottled ``moveend`` resync
-    guarantees the GL transform lands on the final map position. Also bumps
-    maplibre-gl-leaflet 0.0.17 -> 0.0.22, which rounds fractional container
-    positions (sub-pixel misalignment at certain window widths).
+    the next interaction. A single ``moveend`` resync is not reliable on its
+    own: ``_update()`` mutates ``transform.center``/``transform.zoom``
+    directly from whatever the map's current animation state is, so calling
+    it once at the "wrong" instant (e.g. mid-inertia, before layout settles)
+    can itself desync the GL layer. We therefore also register our own
+    unthrottled ``move`` listener -- calling ``_update()`` on every move is
+    cheap and means the transform is recomputed continuously through the
+    drag rather than only once at the end, so a single bad sample doesn't
+    stick. Also bumps maplibre-gl-leaflet 0.0.17 -> 0.0.22, which rounds
+    fractional container positions (sub-pixel misalignment at certain
+    window widths).
     """
 
     _template = branca.element.Template(
@@ -53,12 +60,21 @@ class PMTilesMapLibreLayerSynced(PMTilesMapLibreLayer):
                 interactive: true,
             }).addTo({{ this._parent.get_name() }});
 
-            // Hard resync after every pan/zoom so the GL polygons can never be
-            // left offset from the basemap by a lost throttled 'move' update.
-            {{ this._parent.get_name() }}.on('moveend', function () {
+            // Resync on every 'move' (unthrottled, unlike the library's own
+            // handler) plus once more after 'moveend' settles, so the GL
+            // transform tracks the drag continuously instead of depending on
+            // a single throttled or end-of-drag sample landing correctly.
+            {{ this._parent.get_name() }}.on('move', function () {
                 if ({{ this.get_name() }}._glMap) {
                     {{ this.get_name() }}._update();
                 }
+            });
+            {{ this._parent.get_name() }}.on('moveend', function () {
+                requestAnimationFrame(function () {
+                    if ({{ this.get_name() }}._glMap) {
+                        {{ this.get_name() }}._update();
+                    }
+                }.bind(this));
             });
             {%- endmacro %}
             """

--- a/src/water_timeseries/map_utils.py
+++ b/src/water_timeseries/map_utils.py
@@ -22,6 +22,58 @@ from water_timeseries.utils.visualization import (
 )
 
 
+class PMTilesMapLibreLayerSynced(PMTilesMapLibreLayer):
+    """PMTilesMapLibreLayer with a fix for the GL layer drifting away from the basemap.
+
+    maplibre-gl-leaflet only syncs the GL canvas on throttled Leaflet ``move``
+    events, so the final update of a drag (especially a fast one, or during
+    inertia) can be lost and the polygons stay offset from the basemap until
+    the next interaction. Registering an unthrottled ``moveend`` resync
+    guarantees the GL transform lands on the final map position. Also bumps
+    maplibre-gl-leaflet 0.0.17 -> 0.0.22, which rounds fractional container
+    positions (sub-pixel misalignment at certain window widths).
+    """
+
+    _template = branca.element.Template(
+        """
+            {% macro script(this, kwargs) -%}
+            if (!("pmtiles" in maplibregl.config.REGISTERED_PROTOCOLS)) {
+                var protocol = new pmtiles.Protocol();
+                maplibregl.addProtocol("pmtiles", protocol.tile);
+            }
+
+            // see: https://github.com/maplibre/maplibre-gl-leaflet/issues/19
+            {{ this._parent.get_name() }}.createPane('overlay_{{ this.get_name() }}');
+            {{ this._parent.get_name() }}.getPane('overlay_{{ this.get_name() }}').style.zIndex = 650;
+            {{ this._parent.get_name() }}.getPane('overlay_{{ this.get_name() }}').style.pointerEvents = 'none';
+
+            var {{ this.get_name() }} = L.maplibreGL({
+                pane: 'overlay_{{ this.get_name() }}',
+                style: {{ this.style|tojson}},
+                interactive: true,
+            }).addTo({{ this._parent.get_name() }});
+
+            // Hard resync after every pan/zoom so the GL polygons can never be
+            // left offset from the basemap by a lost throttled 'move' update.
+            {{ this._parent.get_name() }}.on('moveend', function () {
+                if ({{ this.get_name() }}._glMap) {
+                    {{ this.get_name() }}._update();
+                }
+            });
+            {%- endmacro %}
+            """
+    )
+
+    default_js = [
+        ("pmtiles", "https://unpkg.com/pmtiles@2.5.0/dist/index.js"),
+        ("maplibre-lib", "https://unpkg.com/maplibre-gl@2.2.1/dist/maplibre-gl.js"),
+        (
+            "maplibre-leaflet",
+            "https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.0.22/leaflet-maplibre-gl.js",
+        ),
+    ]
+
+
 class PMTilesMapLibreTooltipWithRounding(folium.elements.JSCSSMixin, branca.element.MacroElement):
     _template = branca.element.Template(
         """
@@ -354,7 +406,8 @@ def build_pmtiles_map(
         lakes_fill_layer["filter"] = nan_filter
         lakes_line_layer["filter"] = nan_filter
 
-    lake_layer = PMTilesMapLibreLayer(
+    # setup PMTiles Layer
+    lake_layer = PMTilesMapLibreLayerSynced(
         pmtiles_url,
         "Lakes",
         overlay=True,


### PR DESCRIPTION
The moveend-only resync from movement issues wasn't actually reliable — _update() isn't idempotent, so calling it once after a fast/inertial drag can land at the wrong instant and leave (or even create) an offset. confirmed this with a playwright stress test: same drag, sometimes fixed, sometimes not, once even broke an already-synced state.

fix: also resync on every move event (unthrottled), not just once at moveend. the gl transform tracks the drag continuously and this isn't super expensive.

Verified with headless Firefox (throttled rAF simulates the busy-main-thread race real users hit): before, offset up to ~1900px on almost every fast drag. after, 0px across 24 drags / 3 runs.