### PR TITLE
1/5 Rename dashboard configs after their viz configuration

### DIFF
--- a/configs/dashboard_drainage_year.yaml
+++ b/configs/dashboard_drainage_year.yaml
@@ -18,4 +18,4 @@ dw_start_month: 6
 dw_end_month: 9
 
 viz_configuration: drainage_year
-logfile: logs/dashboard_historical_panarctic.log
+logfile: logs/dashboard_drainage_year_panarctic.log

--- a/configs/dashboard_nrt_drainage.yaml
+++ b/configs/dashboard_nrt_drainage.yaml
@@ -1,5 +1,5 @@
 # CONFIG File for PMTILES config - near-real-time lake drainage, pan-arctic
-# Use via DASHBOARD_CONFIG=configs/dashboard_nrt.yaml.
+# Use via DASHBOARD_CONFIG=configs/dashboard_nrt_drainage.yaml.
 
 ee_project: pdg-project-406720
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,12 +5,12 @@ services:
     working_dir: /app
     # Use the installed CLI (same launch path as production/helm). All data
     # paths live in the config file; point DASHBOARD_CONFIG at another YAML
-    # (e.g. configs/dashboard_nrt.yaml) to switch datasets.
+    # (e.g. configs/dashboard_nrt_drainage.yaml) to switch datasets.
     command:
       - water-timeseries
       - dashboard
       - --config-file
-      - ${DASHBOARD_CONFIG:-configs/dashboard_historical.yaml}
+      - ${DASHBOARD_CONFIG:-configs/dashboard_drainage_year.yaml}
     volumes:
       - .:/app
       # Keep image .venv; a plain .:/app mount would hide it with an empty host dir

--- a/src/water_timeseries/scripts/cli.py
+++ b/src/water_timeseries/scripts/cli.py
@@ -261,13 +261,13 @@ def build_pmtiles(
     ``.pmtiles`` file to object storage (S3, GCS, etc.) and pass ``--pmtiles-url`` to
     the dashboard, or use ``--pmtiles-file`` for local development.
 
-    The same dashboard config (e.g. ``configs/dashboard_historical.yaml``) that hosts
+    The same dashboard config (e.g. ``configs/dashboard_drainage_year.yaml``) that hosts
     the dashboard can be reused here: its ``pmtiles_file`` key is accepted as the
     build output path, so ``--config-file`` works for both building and serving tiles.
 
     Example:
         water-timeseries build-pmtiles lakes.parquet tiles/lakes.pmtiles
-        water-timeseries build-pmtiles --config-file configs/dashboard_historical.yaml
+        water-timeseries build-pmtiles --config-file configs/dashboard_drainage_year.yaml
         water-timeseries dashboard --pmtiles-file tiles/lakes.pmtiles --vector-file lakes.parquet
     """
     # Load config file if provided

--- a/src/water_timeseries/scripts/repartition_parquet.py
+++ b/src/water_timeseries/scripts/repartition_parquet.py
@@ -23,7 +23,7 @@ Example
         data/DW_NRT/.../..._allGeoms_v3_repartitioned.parquet \\
         --row-group-size 2000
 
-Afterwards point ``vector_file`` in ``configs/dashboard_nrt.yaml`` at the
+Afterwards point ``vector_file`` in ``configs/dashboard_nrt_drainage.yaml`` at the
 repartitioned file.
 """
 


### PR DESCRIPTION
Part 1 of 5 of splitting #227 into a reviewable stack. **Base: `main`.**

Pure rename, no behaviour change.

| Before | After |
|--------|-------|
| `configs/dashboard_historical.yaml` | `configs/dashboard_drainage_year.yaml` |
| `configs/dashboard_nrt.yaml` | `configs/dashboard_nrt_drainage.yaml` |

The old names described where the data came from; the new ones match the `viz_configuration` each file already sets (`drainage_year` / `nrt_drainage`), so a config and the styling it selects share a name. This matters for the next PRs in the stack, where mode keys are derived from these names.

Also updates the log file names and every reference in `docker-compose.yaml` and the CLI docstrings.

### Review notes
Git detects both as renames, so the real diff is 7 changed lines. Worth checking: any deployment (helm values, CI, local `DASHBOARD_CONFIG` env) that pins the old filenames.

---
**Stack:** **#1 (this)** → #2 → #3 → #4 → #5
