### PR TITLE
4/5 Speed up the drained-lakes overlay, hide it in NRT mode

### DIFF
--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -149,7 +149,7 @@ class MapViewer:
         self.drained_gdf = drained_gdf
         self.drained_label = drained_label
         self.show_main_layer = show_main_layer
-        self.drained_data = None
+        self.drained_ids: list[str] | None = None
         self.viz_configuration_name = viz_configuration_name
         self.hide_stable_lakes = hide_stable_lakes
 
@@ -356,10 +356,9 @@ class MapViewer:
         center = [self.map_center.get("lat", 65.5), self.map_center.get("lon", -164.1)]
         logger.info(f"Using provided map center: lat={center[0]}, lon={center[1]}")
 
-        drained_ids = None
-        if getattr(self, "drained_data", None) is not None:
-            drained_ids = list(self.drained_data.keys())
-            logger.info(f"Drained data overlay: {len(drained_ids) if drained_ids else 0} lakes")
+        drained_ids = getattr(self, "drained_ids", None) or None
+        if drained_ids is not None:
+            logger.info(f"Drained data overlay: {len(drained_ids)} lakes")
         logger.info("Setting up map")
         tooltip = None
         m = build_pmtiles_map(
@@ -370,6 +369,7 @@ class MapViewer:
             viz_configuration_name=viz_configuration_name,
             tooltip=tooltip,
             hide_stable_lakes=self.hide_stable_lakes,
+            drained_label=getattr(self, "drained_label", None),
         )
 
         # Render the map and get click data
@@ -1298,16 +1298,19 @@ def create_app(
     precomputed_counts: pd.DataFrame | None = st.session_state.precomputed_nrt_counts
     precomputed_breaks: pd.DataFrame | None = st.session_state.precomputed_nrt_breaks
 
-    # Near-real-time drainage overlay
-    st.sidebar.divider()
-    st.sidebar.subheader("Historical Drainage")
-    st.session_state.setdefault("show_drained_toggle", default_activate_historical)
-    show_drained = st.sidebar.toggle(
-        "Show temporal drainage statistics",
-        key="show_drained_toggle",
-        help="Activates visualization of number of drained lakes per month.",
-    )
-    sync_flag_param("drained", show_drained)
+    # Historical drainage overlay. Hidden entirely in Near Real-Time mode,
+    # which has its own per-month drainage controls.
+    show_drained = False
+    if viz_configuration_name != "nrt_drainage":
+        st.sidebar.divider()
+        st.sidebar.subheader("Historical Drainage")
+        st.session_state.setdefault("show_drained_toggle", default_activate_historical)
+        show_drained = st.sidebar.toggle(
+            "Show temporal drainage statistics",
+            key="show_drained_toggle",
+            help="Activates visualization of number of drained lakes per month.",
+        )
+        sync_flag_param("drained", show_drained)
     if not show_drained:
         st.query_params.pop("month", None)
     # Jump to the drainage overview zoom only when the toggle flips on,
@@ -1444,10 +1447,9 @@ def create_app(
                 if show_drained and drained_breaks is not None and not drained_breaks.empty:
                     drained_ids = drained_breaks.index.unique().tolist()
                     if map_backend == "pmtiles":
-                        breaks_df = drained_breaks.copy()
-                        if "date" in breaks_df.columns:
-                            breaks_df["date"] = breaks_df["date"].astype(str)
-                        viewer.drained_data = breaks_df.to_dict(orient="index")
+                        # Only the ids reach the map style, so skip building a
+                        # row-dict for every drained lake just to drop the values.
+                        viewer.drained_ids = drained_ids
                         viewer.drained_label = drained_label
                         viewer.show_main_layer = True
                     else:
@@ -1461,7 +1463,7 @@ def create_app(
                         viewer.show_main_layer = True
                 elif show_drained:
                     viewer.drained_gdf = None
-                    viewer.drained_data = None
+                    viewer.drained_ids = None
                     viewer.drained_label = drained_label
                     viewer.show_main_layer = True
 

--- a/src/water_timeseries/map_utils.py
+++ b/src/water_timeseries/map_utils.py
@@ -18,6 +18,7 @@ from water_timeseries.utils.map_styles.pmtiles import (
 )
 from water_timeseries.utils.visualization import (
     get_legend_html_date_drainage_year,
+    get_legend_html_drained_month,
     get_legend_html_net_change,
     get_legend_html_nrt_drainage,
 )
@@ -263,6 +264,7 @@ def build_pmtiles_map(
     min_zoom=4,
     max_zoom=15,
     hide_stable_lakes: bool = False,
+    drained_label: str | None = None,
 ) -> folium.Map:
     """Return a Folium map with a PMTiles vector layer for lake polygons."""
 
@@ -361,35 +363,21 @@ def build_pmtiles_map(
         tcvis_tile_layer.add_to(m)
         tile_layer_esriworld.add_to(m)
 
+    # The drained set can run to tens of thousands of ids for a single month.
+    # Styling it via per-property ["match", ..., drained_ids, ...] expressions
+    # serialized the id list once per paint property (four copies, ~0.5 MB
+    # each) into the map HTML. Instead the base layers get plain constant
+    # paint for "not drained", and the drained lakes are painted by two
+    # overlay layers whose *filter* carries the id list -- two copies, and
+    # MapLibre applies it as a feature filter rather than a per-property
+    # expression evaluated four times over.
+    drained_overlay_layers: list[dict] = []
     if drained_ids:
-        fill_color = [
-            "match",
-            ["get", "id_geohash"],
-            drained_ids,
-            "#d73027",  # Red fill for drained
-            "#ADD8E6",  # Default color ramp for non-drained
-        ]
-        fill_opacity = [
-            "match",
-            ["get", "id_geohash"],
-            drained_ids,
-            0.9,  # High opacity for drained
-            0.3,  # Dimmer opacity for non-drained
-        ]
-        line_color = [
-            "match",
-            ["get", "id_geohash"],
-            drained_ids,
-            "#7f0000",  # Dark red border for drained
-            "#eeeeee",  # Default border color
-        ]
-        line_width = [
-            "match",
-            ["get", "id_geohash"],
-            drained_ids,
-            2.0,  # Thicker border for drained
-            0.5,  # Default border width
-        ]
+        legend = get_legend_html_drained_month(drained_label)
+        fill_color = "#ADD8E6"  # Default color ramp for non-drained
+        fill_opacity = 0.3  # Dimmer opacity for non-drained
+        line_color = "#eeeeee"  # Default border color
+        line_width = 0.5  # Default border width
 
     lakes_fill_layer = {
         "id": "lakes-fill",
@@ -412,6 +400,34 @@ def build_pmtiles_map(
             "line-opacity": line_opacity,
         },
     }
+
+    if drained_ids:
+        drained_filter = ["in", ["get", "id_geohash"], ["literal", drained_ids]]
+        drained_overlay_layers = [
+            {
+                "id": "lakes-fill-drained",
+                "source": "lakes_pmtiles",
+                "source-layer": source_layer,
+                "type": "fill",
+                "filter": drained_filter,
+                "paint": {
+                    "fill-color": "#d73027",  # Red fill for drained
+                    "fill-opacity": 0.9,  # High opacity for drained
+                },
+            },
+            {
+                "id": "lakes-line-drained",
+                "source": "lakes_pmtiles",
+                "source-layer": source_layer,
+                "type": "line",
+                "filter": drained_filter,
+                "paint": {
+                    "line-color": "#7f0000",  # Dark red border for drained
+                    "line-width": 2.0,  # Thicker border for drained
+                    "line-opacity": line_opacity,
+                },
+            },
+        ]
 
     if viz_configuration_name == "drainage_year" and hide_stable_lakes:
         nan_filter = [
@@ -436,7 +452,7 @@ def build_pmtiles_map(
                     "url": "pmtiles://" + pmtiles_url,
                 }
             },
-            "layers": [lakes_fill_layer, lakes_line_layer],
+            "layers": [lakes_fill_layer, lakes_line_layer, *drained_overlay_layers],
         },
         tooltip=tooltip,
     )

--- a/src/water_timeseries/utils/visualization.py
+++ b/src/water_timeseries/utils/visualization.py
@@ -1,5 +1,6 @@
 """Visualization utilities for GeoDataFrames and map rendering."""
 
+from html import escape
 from typing import Any
 
 import pandas as pd
@@ -373,3 +374,46 @@ def gdf_to_geojson_feature_collection(gdf: pd.DataFrame) -> dict:
         GeoJSON feature collection dictionary.
     """
     return gdf.__geo_interface__
+
+
+# Add legend for the historical drained-lakes month overlay
+def get_legend_html_drained_month(label: str | None = None) -> str:
+    """Generate HTML legend for the drained-lakes overlay of a single month.
+
+    Args:
+        label: Optional month label (e.g. "2019-07") shown in the legend title.
+
+    Returns:
+        HTML string matching the colors used by the drained overlay in
+        ``build_pmtiles_map``: red for drained lakes, light blue for the rest.
+    """
+    title = f"Drained Lakes — {escape(label)}" if label else "Drained Lakes"
+    return f"""
+        <div style="
+            position: fixed;
+            bottom: 40px;
+            right: 10px;
+            width: 200px;
+            height: auto;
+            border: 2px solid grey;
+            z-index: 9999;
+            font-size: 12px;
+            background-color: white;
+            color: #222;
+            padding: 10px;
+            border-radius: 5px;
+            box-shadow: 0 0 15px rgba(0,0,0,0.2);
+        ">
+        <p style="margin: 0 0 8px 0; font-weight: bold;">{title}</p>
+
+        <div style="display: flex; align-items: center; margin-bottom: 4px;">
+            <div style="width: 20px; height: 20px; background-color: rgba(215, 48, 39, 0.9); border: 2px solid #7f0000; border-radius: 3px; margin-right: 8px;"></div>
+            <span>Drained this month</span>
+        </div>
+
+        <div style="display: flex; align-items: center;">
+            <div style="width: 20px; height: 20px; background-color: rgba(173, 216, 230, 0.3); border: 1px solid #eeeeee; border-radius: 3px; margin-right: 8px;"></div>
+            <span>Other lakes</span>
+        </div>
+        </div>
+    """


### PR DESCRIPTION
Part 4 of 5 of splitting #227 into a reviewable stack. **Base: PR 3.**

### The performance problem

The historical drained-lakes overlay painted a whole month by giving each of the four base paint properties a `["match", ["get", "id_geohash"], drained_ids, ...]` expression. The id list was assumed to be a few hundred lakes; real months run to **tens of thousands**, so it was serialized into the map HTML four times over (~0.5 MB a copy) and re-evaluated per property, per feature.

The base layers now get plain constant paint for "not drained", and the drained lakes are painted by **two overlay layers whose `filter` carries the id list** — two copies instead of four, applied as a feature filter rather than a per-property expression. The overlay also gets its own legend naming the month it is showing.

`MapViewer` keeps just the id list (`viewer.drained_ids`) instead of building a row-dict for every drained lake and then dropping the values; only the ids ever reached the map style.

### The NRT fix

Near Real-Time mode no longer renders the **Historical Drainage** sidebar section at all — it has its own per-month drainage controls, and the two sets of controls fought over the same map.

### Review notes

Behaviour should be pixel-identical for the historical overlay; the colours and opacities are carried over unchanged. Worth confirming the drained overlay still sits above the base fill and line layers.

Two things I found while splitting this out but deliberately did **not** change, since they are pre-existing on `main` and out of scope for a mechanical split:

1. **`tests/test_dashboard.py::test_build_pmtiles_map_with_drained_ids` asserts the exact `match`-expression structure this PR removes** — so it *should* fail here. It does not, because it already fails earlier on `main`: it passes `["geohash1", "geohash2"]` as ids, and `pygeohash.decode` rejects them (`ValueError: Invalid character in geohash` — `a`, `i`, `l`, `o` are not in the geohash base32 alphabet). The test is dead, and is masking the coverage gap. It wants valid geohashes and assertions rewritten against the new overlay layers.
2. **The `folium.CircleMarker` loop further down `build_pmtiles_map` still runs `pygeohash.decode` once per drained lake**, which for a 36k–61k-lake month is the dominant remaining cost — likely larger than the expression-serialization cost this PR removes. Untouched here.

Happy to fold either into this PR if preferred.

---
**Stack:** #1 → #2 → #3 → **#4 (this)** → #5
