### PR TITLE
5/5 Outline the selected lake on the map

### DIFF
--- a/src/water_timeseries/dashboard/map_viewer.py
+++ b/src/water_timeseries/dashboard/map_viewer.py
@@ -370,6 +370,8 @@ class MapViewer:
             tooltip=tooltip,
             hide_stable_lakes=self.hide_stable_lakes,
             drained_label=getattr(self, "drained_label", None),
+            selected_id=st.session_state.get("selected_geohash"),
+            id_column=self.id_column,
         )
 
         # Render the map and get click data
@@ -634,6 +636,36 @@ class MapViewer:
                     ).add_to(drained_markers)
                 drained_markers.add_to(m)
                 # -----------------------------------------------
+
+        # Outline the current selection on top of everything else, so it stays
+        # identifiable after the map re-centers on it. Loaded by id rather than
+        # taken from valid_gdf, which may have been sampled down by max_features.
+        selected_id = st.session_state.get("selected_geohash")
+        if selected_id:
+            try:
+                selected_gdf = self.load_drained_gdf([selected_id])
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Could not load geometry for selected lake {selected_id}: {e}")
+                selected_gdf = None
+            if selected_gdf is not None and len(selected_gdf) > 0:
+                selected_geojson = _sanitize_geojson_properties(selected_gdf)
+                # Dark casing under a red core, so the outline reads over the
+                # red end of the net-change ramp as well as over pale lakes.
+                for edge_color, edge_weight in (("#1a1a1a", 7), ("#ff2d2d", 3)):
+                    folium.GeoJson(
+                        selected_geojson,
+                        name="Selected lake",
+                        style_function=get_default_style_function(
+                            fill_color="#ff2d2d",
+                            edge_color=edge_color,
+                            edge_weight=edge_weight,
+                            fill_opacity=0.0,
+                        ),
+                        # The layer sits above the lakes, so let hover/click
+                        # fall through to the feature underneath it.
+                        interactive=False,
+                        control=False,
+                    ).add_to(m)
 
         folium.LayerControl().add_to(m)
 

--- a/src/water_timeseries/map_utils.py
+++ b/src/water_timeseries/map_utils.py
@@ -265,8 +265,18 @@ def build_pmtiles_map(
     max_zoom=15,
     hide_stable_lakes: bool = False,
     drained_label: str | None = None,
+    selected_id: str | None = None,
+    id_column: str = "id_geohash",
 ) -> folium.Map:
-    """Return a Folium map with a PMTiles vector layer for lake polygons."""
+    """Return a Folium map with a PMTiles vector layer for lake polygons.
+
+    Args:
+        selected_id: Lake whose outline is highlighted on top of every other
+            layer, so the current selection stays identifiable after the map
+            re-centers on it.
+        id_column: Tile property holding the lake id (matched against
+            ``selected_id``).
+    """
 
     m = leafmap.Map(
         location=center,
@@ -429,6 +439,40 @@ def build_pmtiles_map(
             },
         ]
 
+    # The selected lake is outlined on top of everything else. Its own filter
+    # means the highlight survives the "hide stable lakes" filter below, and the
+    # dark casing under the red core keeps it readable over the red drained
+    # overlay as well as over the light basemaps.
+    selected_overlay_layers: list[dict] = []
+    if selected_id:
+        selected_filter = ["==", ["get", id_column], selected_id]
+        selected_overlay_layers = [
+            {
+                "id": "lakes-line-selected-casing",
+                "source": "lakes_pmtiles",
+                "source-layer": source_layer,
+                "type": "line",
+                "filter": selected_filter,
+                "paint": {
+                    "line-color": "#1a1a1a",
+                    "line-width": 6.0,
+                    "line-opacity": 0.8,
+                },
+            },
+            {
+                "id": "lakes-line-selected",
+                "source": "lakes_pmtiles",
+                "source-layer": source_layer,
+                "type": "line",
+                "filter": selected_filter,
+                "paint": {
+                    "line-color": "#ff2d2d",
+                    "line-width": 2.5,
+                    "line-opacity": 1.0,
+                },
+            },
+        ]
+
     if viz_configuration_name == "drainage_year" and hide_stable_lakes:
         nan_filter = [
             "all",
@@ -452,7 +496,12 @@ def build_pmtiles_map(
                     "url": "pmtiles://" + pmtiles_url,
                 }
             },
-            "layers": [lakes_fill_layer, lakes_line_layer, *drained_overlay_layers],
+            "layers": [
+                lakes_fill_layer,
+                lakes_line_layer,
+                *drained_overlay_layers,
+                *selected_overlay_layers,
+            ],
         },
         tooltip=tooltip,
     )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -56,3 +56,65 @@ def test_resolve_pmtiles_url_passthrough():
 
     url = "https://storage.googleapis.com/bucket/lakes.pmtiles"
     assert resolve_pmtiles_url(url) == url
+
+
+def _pmtiles_style_layers(m):
+    """Return the MapLibre style layers of the PMTiles child layer of a folium map."""
+    for child in m._children.values():
+        if "pmtiles" in str(type(child)).lower():
+            return child.style["layers"]
+    raise AssertionError("No PMTiles layer found on the map")
+
+
+def test_build_pmtiles_map_without_selection_has_no_highlight():
+    from water_timeseries.map_utils import build_pmtiles_map
+
+    m = build_pmtiles_map("https://example.com/lakes.pmtiles")
+    layer_ids = [lyr["id"] for lyr in _pmtiles_style_layers(m)]
+    assert "lakes-line-selected" not in layer_ids
+
+
+def test_build_pmtiles_map_highlights_selected_lake():
+    from water_timeseries.map_utils import build_pmtiles_map
+
+    selected_id = "bd7jm4wqnb0h"
+    m = build_pmtiles_map("https://example.com/lakes.pmtiles", selected_id=selected_id)
+    layers = _pmtiles_style_layers(m)
+    layer_ids = [lyr["id"] for lyr in layers]
+
+    # Casing below the red core, and both on top of every other layer.
+    assert layer_ids[-2:] == ["lakes-line-selected-casing", "lakes-line-selected"]
+
+    highlight = layers[-1]
+    assert highlight["type"] == "line"
+    assert highlight["filter"] == ["==", ["get", "id_geohash"], selected_id]
+    assert highlight["paint"]["line-color"] == "#ff2d2d"
+
+
+def test_build_pmtiles_map_highlight_respects_id_column():
+    from water_timeseries.map_utils import build_pmtiles_map
+
+    m = build_pmtiles_map(
+        "https://example.com/lakes.pmtiles",
+        selected_id="lake-42",
+        id_column="lake_id",
+    )
+    highlight = _pmtiles_style_layers(m)[-1]
+    assert highlight["filter"] == ["==", ["get", "lake_id"], "lake-42"]
+
+
+def test_build_pmtiles_map_highlight_survives_hide_stable_lakes():
+    """The highlight carries its own filter, so hiding stable lakes can't drop it."""
+    from water_timeseries.map_utils import build_pmtiles_map
+
+    selected_id = "bd7jm4wqnb0h"
+    m = build_pmtiles_map(
+        "https://example.com/lakes.pmtiles",
+        viz_configuration_name="drainage_year",
+        hide_stable_lakes=True,
+        selected_id=selected_id,
+    )
+    layers = {lyr["id"]: lyr for lyr in _pmtiles_style_layers(m)}
+
+    assert layers["lakes-fill"]["filter"][0] == "all"  # stable lakes filtered out
+    assert layers["lakes-line-selected"]["filter"] == ["==", ["get", "id_geohash"], selected_id]


### PR DESCRIPTION
Part 5 of 5 of splitting #227 into a reviewable stack. **Base: PR 4.**

Clicking a lake re-centered the map on it, but nothing marked *which* lake was selected, so on a dense map the selection was lost as soon as it moved. The selected lake now gets an outline drawn on top of every other layer.

- **PMTiles path:** two line layers filtered to the selected id. Because the highlight carries its own filter, it survives the "hide stable lakes" filter and does not depend on the lake being present in whatever the main layer sampled. A dark casing under the red core keeps it readable over the red end of the drainage-year ramp and over the red drained-month overlay alike.
- **Folium path:** the same, via a `GeoJson` overlay. The geometry is loaded by id rather than taken from `valid_gdf`, which `max_features` may have sampled down. It is non-interactive, so hover and click fall through to the feature underneath.

**Tests:** four cases in `tests/test_dashboard.py` covering absence of the highlight when nothing is selected, layer ordering, a non-default `id_column`, and survival of the `hide_stable_lakes` filter.

---
**Stack:** #1 → #2 → #3 → #4 → **#5 (this)**
